### PR TITLE
Fix link to API docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ or
 
 ## API
 
-The full API documentation for the latest published version of this library is [available here](https://metamask.github.io/eth-sig-util/index.html).
+The full API documentation for the latest published version of this library is [available here](https://metamask.github.io/utils/index.html).
 
 ## Contributing
 


### PR DESCRIPTION
This PR fixes the link to this library's API docs in the README, which was pointing to a different repository.