### PR TITLE
Add JSON storage limit utilities

### DIFF
--- a/src/json.test.ts
+++ b/src/json.test.ts
@@ -394,5 +394,29 @@ describe('json', () => {
         getJsonSerializableInfo(nonSerializableNestedObject, true),
       ).toStrictEqual([false, 0]);
     });
+
+    it('should return false for serialization and 0 for a size when checking circular structure with an array', () => {
+      const arr: any[][] = [];
+      arr[0] = arr;
+      const circularStructure = {
+        // eslint-disable-next-line no-invalid-this
+        value: arr,
+      };
+      expect(getJsonSerializableInfo(circularStructure, true)).toStrictEqual([
+        false,
+        0,
+      ]);
+    });
+
+    it('should return false for serialization and 0 for a size when checking circular structure with an object', () => {
+      const circularStructure = {
+        value: {},
+      };
+      circularStructure.value = circularStructure;
+      expect(getJsonSerializableInfo(circularStructure, true)).toStrictEqual([
+        false,
+        0,
+      ]);
+    });
   });
 });

--- a/src/json.test.ts
+++ b/src/json.test.ts
@@ -358,10 +358,10 @@ describe('json', () => {
       ).toStrictEqual([true, 73]);
     });
 
-    it('should return true for serialization and 1051 for a size of a complex nested object', () => {
+    it('should return true for serialization and 1153 for a size of a complex nested object', () => {
       expect(getJsonSerializableInfo(complexObject)).toStrictEqual([
         true,
-        1051,
+        1153,
       ]);
     });
 

--- a/src/json.test.ts
+++ b/src/json.test.ts
@@ -1,4 +1,11 @@
 import {
+  arrayOfDifferentKindsOfNumbers,
+  arrayOfMixedSpecialObjects,
+  complexObject,
+  nonSerializableNestedObject,
+  objectMixedWithUndefinedValues,
+} from './test.data';
+import {
   assertIsJsonRpcFailure,
   assertIsJsonRpcNotification,
   assertIsJsonRpcRequest,
@@ -334,139 +341,24 @@ describe('json', () => {
     });
 
     it('should return true for serialization and 25 for a size when some of the values are undefined', () => {
-      const valueToSerialize = {
-        a: undefined,
-        b: 'b',
-        c: undefined,
-        d: 'd',
-        e: undefined,
-        f: 'f',
-      };
-
-      expect(getJsonSerializableInfo(valueToSerialize)).toStrictEqual([
-        true,
-        25,
-      ]);
+      expect(
+        getJsonSerializableInfo(objectMixedWithUndefinedValues),
+      ).toStrictEqual([true, 25]);
     });
 
     it('should return true for serialization and 17 for a size with mixed null and undefined in an array', () => {
-      const valueToSerialize = [
-        null,
-        undefined,
-        null,
-        undefined,
-        undefined,
-        undefined,
-        null,
-        null,
-        null,
-        undefined,
-      ];
-
-      expect(getJsonSerializableInfo(valueToSerialize)).toStrictEqual([
-        true,
-        51,
-      ]);
+      expect(
+        getJsonSerializableInfo(arrayOfMixedSpecialObjects),
+      ).toStrictEqual([true, 51]);
     });
 
     it('should return true for serialization and 73 for a size, for an array of numbers', () => {
-      const valueToSerialize = [
-        -5e-11,
-        5e-9,
-        0.000000000001,
-        -0.00000000009,
-        100000.00000008,
-        -100.88888,
-        0.333,
-        1000000000000,
-      ];
-
-      expect(getJsonSerializableInfo(valueToSerialize)).toStrictEqual([
-        true,
-        73,
-      ]);
+      expect(
+        getJsonSerializableInfo(arrayOfDifferentKindsOfNumbers),
+      ).toStrictEqual([true, 73]);
     });
 
     it('should return true for serialization and 1018 for a size of a complex nested object', () => {
-      const complexObject = {
-        data: {
-          account: {
-            __typename: 'Account',
-            registrations: [
-              {
-                __typename: 'Registration',
-                domain: {
-                  __typename: 'Domain',
-                  isMigrated: true,
-                  labelName: 'mycrypto',
-                  labelhash:
-                    '0x9a781ca0d227debc3ee76d547c960b0803a6c9f58c6d3b4722f12ede7e6ef7c9',
-                  name: 'mycrypto.eth',
-                  parent: { __typename: 'Domain', name: 'eth' },
-                },
-                expiryDate: '1754111315',
-              },
-            ],
-          },
-          moreComplexity: {
-            numbers: [
-              -5e-11,
-              5e-9,
-              0.000000000001,
-              -0.00000000009,
-              100000.00000008,
-              -100.88888,
-              0.333,
-              1000000000000,
-            ],
-            moreNestedObjects: {
-              nestedAgain: {
-                nestedAgain: {
-                  andAgain: {
-                    andAgain: {
-                      value: true,
-                      again: {
-                        value: false,
-                      },
-                    },
-                  },
-                },
-              },
-            },
-            differentEncodings: {
-              ascii:
-                '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~',
-              utf8: 'šđćčžЀЂЇЄЖФћΣΩδλ',
-              mixed: 'ABCDEFGHIJ KLMNOPQRST UVWXYZšđćč žЀЂЇЄЖФћΣΩδλ',
-            },
-            specialObjectsTypesAndValues: {
-              t: [true, true, true],
-              f: [false, false, false],
-              nulls: [null, null, null],
-              undef: undefined,
-              mixed: [
-                null,
-                undefined,
-                null,
-                undefined,
-                null,
-                true,
-                null,
-                false,
-                null,
-                undefined,
-              ],
-              inObject: {
-                valueOne: null,
-                valueTwo: undefined,
-                t: true,
-                f: false,
-              },
-            },
-          },
-        },
-      };
-
       expect(getJsonSerializableInfo(complexObject)).toStrictEqual([
         true,
         1018,
@@ -485,22 +377,9 @@ describe('json', () => {
     });
 
     it('should return false for serialization and 0 for size when non-serializable nested object was provided', () => {
-      const valueToSerialize = {
-        levelOne: {
-          levelTwo: {
-            levelThree: {
-              levelFour: {
-                levelFive: new Set(),
-              },
-            },
-          },
-        },
-      };
-
-      expect(getJsonSerializableInfo(valueToSerialize)).toStrictEqual([
-        false,
-        0,
-      ]);
+      expect(
+        getJsonSerializableInfo(nonSerializableNestedObject),
+      ).toStrictEqual([false, 0]);
     });
   });
 });

--- a/src/json.test.ts
+++ b/src/json.test.ts
@@ -400,7 +400,7 @@ describe('json', () => {
     });
 
     it('should return false for serialization and 0 for a size when checking circular structure with an array', () => {
-      const arr: any[][] = [];
+      const arr: unknown[] = [];
       arr[0] = arr;
       const circularStructure = {
         value: arr,
@@ -451,12 +451,12 @@ describe('json', () => {
       // https://github.com/tc39/test262/tree/main/test/built-ins/JSON/stringify
 
       // Value: array circular
-      const direct: any = [];
+      const direct: unknown[] = [];
       direct.push(direct);
 
       expect(getJsonSerializableInfo(direct)).toStrictEqual([false, 0]);
 
-      const indirect: any = [];
+      const indirect: unknown[] = [];
       indirect.push([[indirect]]);
 
       expect(getJsonSerializableInfo(indirect)).toStrictEqual([false, 0]);

--- a/src/json.test.ts
+++ b/src/json.test.ts
@@ -315,14 +315,25 @@ describe('json', () => {
   });
 
   describe('getJsonSerializableInfo', () => {
-    it('should return true for serialization and 14 for a size', () => {
+    it('should return true for serialization and 10 for a size', () => {
       const valueToSerialize = {
         a: 'bc',
       };
 
       expect(getJsonSerializableInfo(valueToSerialize)).toStrictEqual([
         true,
-        12,
+        10,
+      ]);
+    });
+
+    it('should return true for serialization and 16 for a size when mixed UTF8 and ASCII values are used', () => {
+      const valueToSerialize = {
+        a: 'bcšečf',
+      };
+
+      expect(getJsonSerializableInfo(valueToSerialize)).toStrictEqual([
+        true,
+        16,
       ]);
     });
   });

--- a/src/json.test.ts
+++ b/src/json.test.ts
@@ -3,6 +3,7 @@ import {
   assertIsJsonRpcNotification,
   assertIsJsonRpcRequest,
   assertIsJsonRpcSuccess,
+  calculateNumberSize,
   getJsonRpcIdValidator,
   getJsonSerializableInfo,
   isJsonRpcFailure,
@@ -314,10 +315,39 @@ describe('json', () => {
     });
   });
 
+  describe('calculateNumberSize', () => {
+    it('should return 3 for a "100" number size', () => {
+      expect(calculateNumberSize(100)).toBe(3);
+    });
+
+    it('should return 4 for a "-100" number size', () => {
+      expect(calculateNumberSize(-100)).toBe(4);
+    });
+
+    it('should return 4 for a "-0.3" number size', () => {
+      expect(calculateNumberSize(-0.3)).toBe(4);
+    });
+
+    it('should return 12 for a "0.0000000005" number size', () => {
+      expect(calculateNumberSize(0.0000000005)).toBe(12);
+    });
+  });
+
   describe('getJsonSerializableInfo', () => {
     it('should return true for serialization and 10 for a size', () => {
       const valueToSerialize = {
         a: 'bc',
+      };
+
+      expect(getJsonSerializableInfo(valueToSerialize)).toStrictEqual([
+        true,
+        10,
+      ]);
+    });
+
+    it('should return true for serialization and 11 for a size', () => {
+      const valueToSerialize = {
+        a: 1234,
       };
 
       expect(getJsonSerializableInfo(valueToSerialize)).toStrictEqual([

--- a/src/json.test.ts
+++ b/src/json.test.ts
@@ -4,10 +4,12 @@ import {
   assertIsJsonRpcRequest,
   assertIsJsonRpcSuccess,
   getJsonRpcIdValidator,
+  getJsonSerializableInfo,
   isJsonRpcFailure,
   isJsonRpcNotification,
   isJsonRpcRequest,
   isJsonRpcSuccess,
+  isPlainObject,
   isValidJson,
   jsonrpc2,
   JsonRpcError,
@@ -284,6 +286,44 @@ describe('json', () => {
           inputs,
         ),
       ).not.toThrow();
+    });
+  });
+
+  describe('isPlainObject', () => {
+    it('should return true for a plain object', () => {
+      const somePlainObject = {
+        someKey: 'someValue',
+      };
+
+      expect(isPlainObject(somePlainObject)).toBe(true);
+    });
+
+    it('should return false if function is passed', () => {
+      const someFunction = (someArg: string) => {
+        return someArg;
+      };
+
+      expect(isPlainObject(someFunction)).toBe(false);
+    });
+
+    it('should return false if Set object is passed', () => {
+      const someSet = new Set();
+      someSet.add('something');
+
+      expect(isPlainObject(someSet)).toBe(false);
+    });
+  });
+
+  describe('getJsonSerializableInfo', () => {
+    it('should return true for serialization and 14 for a size', () => {
+      const valueToSerialize = {
+        a: 'bc',
+      };
+
+      expect(getJsonSerializableInfo(valueToSerialize)).toStrictEqual([
+        true,
+        12,
+      ]);
     });
   });
 });

--- a/src/json.test.ts
+++ b/src/json.test.ts
@@ -321,5 +321,135 @@ describe('json', () => {
         16,
       ]);
     });
+
+    it('should return true for serialization and 2 for a size when only one key with undefined value is provided', () => {
+      const valueToSerialize = {
+        a: undefined,
+      };
+
+      expect(getJsonSerializableInfo(valueToSerialize)).toStrictEqual([
+        true,
+        2,
+      ]);
+    });
+
+    it('should return true for serialization and 25 for a size when some of the values are undefined', () => {
+      const valueToSerialize = {
+        a: undefined,
+        b: 'b',
+        c: undefined,
+        d: 'd',
+        e: undefined,
+        f: 'f',
+      };
+
+      expect(getJsonSerializableInfo(valueToSerialize)).toStrictEqual([
+        true,
+        25,
+      ]);
+    });
+
+    it('should return true for serialization and 17 for a size with mixed null and undefined in an array', () => {
+      const valueToSerialize = [
+        null,
+        undefined,
+        null,
+        undefined,
+        undefined,
+        undefined,
+        null,
+        null,
+        null,
+        undefined,
+      ];
+
+      expect(getJsonSerializableInfo(valueToSerialize)).toStrictEqual([
+        true,
+        51,
+      ]);
+    });
+
+    it('should return true for serialization and 1022 for a size of a complex nested object', () => {
+      const complexObject = {
+        data: {
+          account: {
+            __typename: 'Account',
+            registrations: [
+              {
+                __typename: 'Registration',
+                domain: {
+                  __typename: 'Domain',
+                  isMigrated: true,
+                  labelName: 'mycrypto',
+                  labelhash:
+                    '0x9a781ca0d227debc3ee76d547c960b0803a6c9f58c6d3b4722f12ede7e6ef7c9',
+                  name: 'mycrypto.eth',
+                  parent: { __typename: 'Domain', name: 'eth' },
+                },
+                expiryDate: '1754111315',
+              },
+            ],
+          },
+          moreComplexity: {
+            // numbers: [
+            //   -5e-11,
+            //   5e-9,
+            //   0.000000000001,
+            //   -0.00000000009,
+            //   100000.00000008,
+            //   -100.88888,
+            //   0.333,
+            //   1000000000000,
+            // ],
+            moreNestedObjects: {
+              nestedAgain: {
+                nestedAgain: {
+                  andAgain: {
+                    andAgain: {
+                      value: true,
+                      again: {
+                        value: false,
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            differentEncodings: {
+              ascii:
+                '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~',
+              utf8: 'šđćčžЀЂЇЄЖФћΣΩδλ',
+              mixed: 'ABCDEFGHIJ KLMNOPQRST UVWXYZšđćč žЀЂЇЄЖФћΣΩδλ',
+            },
+            specialObjectsTypesAndValues: {
+              t: [true, true, true],
+              f: [false, false, false],
+              nulls: [null, null, null],
+              undef: undefined,
+              mixed: [
+                null,
+                undefined,
+                null,
+                undefined,
+                null,
+                true,
+                null,
+                false,
+                null,
+                undefined,
+              ],
+              inObject: {
+                valueOne: null,
+                valueTwo: undefined,
+                t: true,
+                f: false,
+              },
+            },
+          },
+        },
+      };
+
+      expect(getJsonSerializableInfo(complexObject)).toStrictEqual([true, 934]);
+    });
   });
 });

--- a/src/json.test.ts
+++ b/src/json.test.ts
@@ -3,14 +3,12 @@ import {
   assertIsJsonRpcNotification,
   assertIsJsonRpcRequest,
   assertIsJsonRpcSuccess,
-  calculateNumberSize,
   getJsonRpcIdValidator,
   getJsonSerializableInfo,
   isJsonRpcFailure,
   isJsonRpcNotification,
   isJsonRpcRequest,
   isJsonRpcSuccess,
-  isPlainObject,
   isValidJson,
   jsonrpc2,
   JsonRpcError,
@@ -287,49 +285,6 @@ describe('json', () => {
           inputs,
         ),
       ).not.toThrow();
-    });
-  });
-
-  describe('isPlainObject', () => {
-    it('should return true for a plain object', () => {
-      const somePlainObject = {
-        someKey: 'someValue',
-      };
-
-      expect(isPlainObject(somePlainObject)).toBe(true);
-    });
-
-    it('should return false if function is passed', () => {
-      const someFunction = (someArg: string) => {
-        return someArg;
-      };
-
-      expect(isPlainObject(someFunction)).toBe(false);
-    });
-
-    it('should return false if Set object is passed', () => {
-      const someSet = new Set();
-      someSet.add('something');
-
-      expect(isPlainObject(someSet)).toBe(false);
-    });
-  });
-
-  describe('calculateNumberSize', () => {
-    it('should return 3 for a "100" number size', () => {
-      expect(calculateNumberSize(100)).toBe(3);
-    });
-
-    it('should return 4 for a "-100" number size', () => {
-      expect(calculateNumberSize(-100)).toBe(4);
-    });
-
-    it('should return 4 for a "-0.3" number size', () => {
-      expect(calculateNumberSize(-0.3)).toBe(4);
-    });
-
-    it('should return 12 for a "0.0000000005" number size', () => {
-      expect(calculateNumberSize(0.0000000005)).toBe(12);
     });
   });
 

--- a/src/json.test.ts
+++ b/src/json.test.ts
@@ -358,11 +358,22 @@ describe('json', () => {
       ).toStrictEqual([true, 73]);
     });
 
-    it('should return true for serialization and 1153 for a size of a complex nested object', () => {
+    it('should return true for serialization and 1259 for a size of a complex nested object', () => {
       expect(getJsonSerializableInfo(complexObject)).toStrictEqual([
         true,
-        1153,
+        1259,
       ]);
+    });
+
+    it('should return true for serialization and 107 for a size of an object containing Date object', () => {
+      const dateObjects = {
+        dates: {
+          someDate: new Date(),
+          someOther: new Date(2022, 0, 2, 15, 4, 5),
+          invalidDate: new Date('bad-date-format'),
+        },
+      };
+      expect(getJsonSerializableInfo(dateObjects)).toStrictEqual([true, 107]);
     });
 
     it('should return false for serialization and 0 for size when non-serializable object was provided', () => {

--- a/src/json.test.ts
+++ b/src/json.test.ts
@@ -472,5 +472,16 @@ describe('json', () => {
         1018,
       ]);
     });
+
+    it('should return false for serialization and 0 for size when non-serializable object was provided', () => {
+      const valueToSerialize = {
+        value: new Set(),
+      };
+
+      expect(getJsonSerializableInfo(valueToSerialize)).toStrictEqual([
+        false,
+        0,
+      ]);
+    });
   });
 });

--- a/src/json.test.ts
+++ b/src/json.test.ts
@@ -778,7 +778,8 @@ describe('json', () => {
       ]);
     });
 
-    it('should return true for validity for an object that contains same object multiple times', () => {
+    it('should return true for validity for an object that contains the same object multiple times', () => {
+      // This will test if false positives are removed from the circular reference detection
       const date = new Date();
       const testObject = {
         value: 'whatever',
@@ -806,6 +807,14 @@ describe('json', () => {
           something: null,
           somethingElse: null,
           anotherValue: null,
+          somethingAgain: testObject,
+          anotherOne: {
+            nested: {
+              multipleTimes: {
+                valueOne: testObject,
+              },
+            },
+          },
         },
       };
 

--- a/src/json.test.ts
+++ b/src/json.test.ts
@@ -777,5 +777,42 @@ describe('json', () => {
         0,
       ]);
     });
+
+    it('should return true for validity for an object that contains same object multiple times', () => {
+      const date = new Date();
+      const testObject = {
+        value: 'whatever',
+      };
+      const objectToTest = {
+        a: date,
+        b: date,
+        c: date,
+        testOne: testObject,
+        testTwo: testObject,
+        testThree: {
+          nestedObjectTest: {
+            multipleTimes: {
+              valueOne: testObject,
+              valueTwo: testObject,
+              valueThree: testObject,
+              valueFour: testObject,
+              valueFive: date,
+              valueSix: {},
+            },
+          },
+        },
+        testFour: {},
+        testFive: {
+          something: null,
+          somethingElse: null,
+          anotherValue: null,
+        },
+      };
+
+      expect(validateJsonAndGetSize(objectToTest, true)).toStrictEqual([
+        true,
+        0,
+      ]);
+    });
   });
 });

--- a/src/json.test.ts
+++ b/src/json.test.ts
@@ -358,10 +358,10 @@ describe('json', () => {
       ).toStrictEqual([true, 73]);
     });
 
-    it('should return true for serialization and 1018 for a size of a complex nested object', () => {
+    it('should return true for serialization and 1051 for a size of a complex nested object', () => {
       expect(getJsonSerializableInfo(complexObject)).toStrictEqual([
         true,
-        1018,
+        1051,
       ]);
     });
 

--- a/src/json.test.ts
+++ b/src/json.test.ts
@@ -399,7 +399,6 @@ describe('json', () => {
       const arr: any[][] = [];
       arr[0] = arr;
       const circularStructure = {
-        // eslint-disable-next-line no-invalid-this
         value: arr,
       };
       expect(getJsonSerializableInfo(circularStructure, true)).toStrictEqual([

--- a/src/json.test.ts
+++ b/src/json.test.ts
@@ -369,7 +369,25 @@ describe('json', () => {
       ]);
     });
 
-    it('should return true for serialization and 1022 for a size of a complex nested object', () => {
+    it('should return true for serialization and 73 for a size, for an array of numbers', () => {
+      const valueToSerialize = [
+        -5e-11,
+        5e-9,
+        0.000000000001,
+        -0.00000000009,
+        100000.00000008,
+        -100.88888,
+        0.333,
+        1000000000000,
+      ];
+
+      expect(getJsonSerializableInfo(valueToSerialize)).toStrictEqual([
+        true,
+        73,
+      ]);
+    });
+
+    it('should return true for serialization and 1018 for a size of a complex nested object', () => {
       const complexObject = {
         data: {
           account: {
@@ -391,16 +409,16 @@ describe('json', () => {
             ],
           },
           moreComplexity: {
-            // numbers: [
-            //   -5e-11,
-            //   5e-9,
-            //   0.000000000001,
-            //   -0.00000000009,
-            //   100000.00000008,
-            //   -100.88888,
-            //   0.333,
-            //   1000000000000,
-            // ],
+            numbers: [
+              -5e-11,
+              5e-9,
+              0.000000000001,
+              -0.00000000009,
+              100000.00000008,
+              -100.88888,
+              0.333,
+              1000000000000,
+            ],
             moreNestedObjects: {
               nestedAgain: {
                 nestedAgain: {
@@ -449,7 +467,10 @@ describe('json', () => {
         },
       };
 
-      expect(getJsonSerializableInfo(complexObject)).toStrictEqual([true, 934]);
+      expect(getJsonSerializableInfo(complexObject)).toStrictEqual([
+        true,
+        1018,
+      ]);
     });
   });
 });

--- a/src/json.test.ts
+++ b/src/json.test.ts
@@ -417,5 +417,27 @@ describe('json', () => {
         0,
       ]);
     });
+
+    it('should return false for serialization and 0 for a size when checking object containing symbols', () => {
+      const objectContainingSymbols = {
+        mySymbol: Symbol('MySymbol'),
+      };
+      expect(getJsonSerializableInfo(objectContainingSymbols)).toStrictEqual([
+        false,
+        0,
+      ]);
+    });
+
+    it('should return false for serialization and 0 for a size when checking an array containing a function', () => {
+      const objectContainingFunction = [
+        function () {
+          return 'whatever';
+        },
+      ];
+      expect(getJsonSerializableInfo(objectContainingFunction)).toStrictEqual([
+        false,
+        0,
+      ]);
+    });
   });
 });

--- a/src/json.test.ts
+++ b/src/json.test.ts
@@ -483,5 +483,24 @@ describe('json', () => {
         0,
       ]);
     });
+
+    it('should return false for serialization and 0 for size when non-serializable nested object was provided', () => {
+      const valueToSerialize = {
+        levelOne: {
+          levelTwo: {
+            levelThree: {
+              levelFour: {
+                levelFive: new Set(),
+              },
+            },
+          },
+        },
+      };
+
+      expect(getJsonSerializableInfo(valueToSerialize)).toStrictEqual([
+        false,
+        0,
+      ]);
+    });
   });
 });

--- a/src/json.test.ts
+++ b/src/json.test.ts
@@ -381,5 +381,18 @@ describe('json', () => {
         getJsonSerializableInfo(nonSerializableNestedObject),
       ).toStrictEqual([false, 0]);
     });
+
+    it('should return true for serialization and 0 for a size when sizing is skipped', () => {
+      expect(getJsonSerializableInfo(complexObject, true)).toStrictEqual([
+        true,
+        0,
+      ]);
+    });
+
+    it('should return false for serialization and 0 for a size when sizing is skipped and non-serializable object was provided', () => {
+      expect(
+        getJsonSerializableInfo(nonSerializableNestedObject, true),
+      ).toStrictEqual([false, 0]);
+    });
   });
 });

--- a/src/json.ts
+++ b/src/json.ts
@@ -353,7 +353,10 @@ export function getJsonSerializableInfo(
           const separator = idx < arr.length - 1 ? JsonSize.Comma : 0;
           // If the size is 0, that means the object is undefined and
           // the rest of the object structure will be omitted
-          return size === 0 ? sum : sum + keySize + size + separator;
+          if (size === 0) {
+            return sum;
+          }
+          return sum + keySize + size + separator;
         },
         // Starts at 2 because the serialized JSON string data (plain text)
         // will minimally contain {}/[]

--- a/src/json.ts
+++ b/src/json.ts
@@ -355,10 +355,13 @@ export function validateJsonAndGetSize(
       return [false, 0];
     }
 
-    // Handle circular objects
+    // Circular object detection (handling)
+    // Check if the same object already exists
     if (seenObjects.has(value)) {
       return [false, 0];
     }
+    // Add new object to the seen objects set
+    // Only the plain objects should be added (Primitive types are skipped)
     seenObjects.add(value);
 
     // Continue object decomposition
@@ -378,7 +381,12 @@ export function validateJsonAndGetSize(
                 'JSON validation did not pass. Validation process stopped.',
               );
             }
+
+            // Circular object detection
+            // Once a child node is visited and processed remove it from the set.
+            // This will prevent false positives with the same adjacent objects.
             seenObjects.delete(value);
+
             if (skipSizing) {
               return 0;
             }

--- a/src/json.ts
+++ b/src/json.ts
@@ -286,7 +286,7 @@ export function validateJsonAndGetSize(
   jsObject: unknown,
   skipSizingProcess = false,
 ): [isValid: boolean, plainTextSizeInBytes: number] {
-  const seenObjects: unknown[] = [];
+  const seenObjects = new Set();
   /**
    * Checks whether a value is JSON serializable and counts the total number
    * of bytes needed to store the serialized version of the value.
@@ -374,10 +374,10 @@ export function validateJsonAndGetSize(
     }
 
     // Handle circular objects
-    if (seenObjects.indexOf(value) !== -1) {
+    if (seenObjects.has(value)) {
       return [false, 0];
     }
-    seenObjects.push(value);
+    seenObjects.add(value);
 
     // Continue object decomposition
     try {
@@ -396,7 +396,7 @@ export function validateJsonAndGetSize(
                 'JSON validation did not pass. Validation process stopped.',
               );
             }
-
+            seenObjects.delete(value);
             if (skipSizing) {
               return 0;
             }

--- a/src/json.ts
+++ b/src/json.ts
@@ -281,8 +281,8 @@ export function getJsonRpcIdValidator(options?: JsonRpcValidatorOptions) {
  *
  * @param value - A potential JSON serializable value.
  * @param skipSizing - Skip JSON size calculation (default: false).
- * @returns A tuple containing a boolean that signals whether the value was serializable and
- * a number of bytes that it will use when serialized to JSON.
+ * @returns A tuple [isValid, plainTextSizeInBytes] containing a boolean that signals whether
+ * the value was serializable and a number of bytes that it will use when serialized to JSON.
  */
 export function getJsonSerializableInfo(
   value: unknown,
@@ -329,7 +329,9 @@ export function getJsonSerializableInfo(
           // eslint-disable-next-line prefer-const
           let [valid, size] = getJsonSerializableInfo(nestedValue, skipSizing);
           if (!valid) {
-            throw new Error();
+            throw new Error(
+              'JSON validation did not pass. Validation process stopped.',
+            );
           }
 
           if (skipSizing) {

--- a/src/json.ts
+++ b/src/json.ts
@@ -296,14 +296,14 @@ export function getJsonSerializableInfo(value: unknown): [boolean, number] {
   // eslint-disable-next-line default-case
   switch (typeof value) {
     case 'string':
-      // TODO: Check if character is ASCII (1B) or UTF-8 (2B)
-      return [true, value.length * 2 + QUOTE_LENGTH * 2];
+      return [true, calculateStringSize(value) + QUOTE_LENGTH * 2];
     case 'boolean':
       return [true, value ? TRUE_LENGTH : FALSE_LENGTH];
     case 'number':
       return [
         true,
         // Check number of digits since all digits are 1 byte
+        // TODO: This needs to be improved to handle negative and decimal numbers
         value === 0 ? ZERO_LENGTH : Math.floor(Math.log10(value) + 1),
       ];
   }
@@ -360,4 +360,34 @@ export function isPlainObject(value: unknown): value is PlainObject {
   } catch (_) {
     return false;
   }
+}
+
+/**
+ * Check if character or string is ASCII.
+ *
+ * @param value - String or character.
+ * @returns Boolean, true if value is ASCII, false if not.
+ */
+export function isASCII(value: string) {
+  // eslint-disable-next-line no-control-regex,require-unicode-regexp
+  return /^[\x00-\x7F]*$/.test(value);
+}
+
+/**
+ * Calculate string size.
+ *
+ * @param value - String value to calculate size.
+ * @returns Number of bytes used to store whole string value.
+ */
+export function calculateStringSize(value: string) {
+  let size = 0;
+  for (const character of value) {
+    if (isASCII(character)) {
+      size += 1;
+    } else {
+      size += 2;
+    }
+  }
+
+  return size;
 }

--- a/src/json.ts
+++ b/src/json.ts
@@ -310,28 +310,30 @@ export function validateJsonAndGetSize(
       return [true, skipSizing ? 0 : JsonSize.Null];
     }
 
-    // Check and calculate sizes for basic types
-    // eslint-disable-next-line default-case
-    switch (typeof value) {
-      case 'function':
+    // Check and calculate sizes for basic (and some special) types
+    const typeOfValue = typeof value;
+    try {
+      if (typeOfValue === 'function') {
         return [false, 0];
-      case 'string':
+      } else if (typeOfValue === 'string' || value instanceof String) {
         return [
           true,
-          skipSizing ? 0 : calculateStringSize(value) + JsonSize.Quote * 2,
+          skipSizing
+            ? 0
+            : calculateStringSize(value as string) + JsonSize.Quote * 2,
         ];
-      case 'boolean':
+      } else if (typeOfValue === 'boolean' || value instanceof Boolean) {
         if (skipSizing) {
           return [true, 0];
         }
-        return [true, value ? JsonSize.True : JsonSize.False];
-      case 'number':
-        return [true, skipSizing ? 0 : calculateNumberSize(value)];
-    }
-
-    // Handle specific complex objects that can be serialized properly
-    try {
-      if (value instanceof Date) {
+        // eslint-disable-next-line eqeqeq
+        return [true, value == true ? JsonSize.True : JsonSize.False];
+      } else if (typeOfValue === 'number' || value instanceof Number) {
+        if (skipSizing) {
+          return [true, 0];
+        }
+        return [true, calculateNumberSize(value as number)];
+      } else if (value instanceof Date) {
         if (skipSizing) {
           return [true, 0];
         }
@@ -341,25 +343,6 @@ export function validateJsonAndGetSize(
           isNaN(value.getDate())
             ? JsonSize.Null
             : JsonSize.Date + JsonSize.Quote * 2,
-        ];
-      } else if (value instanceof Boolean) {
-        if (skipSizing) {
-          return [true, 0];
-        }
-        // eslint-disable-next-line eqeqeq
-        return [true, value == true ? JsonSize.True : JsonSize.False];
-      } else if (value instanceof Number) {
-        if (skipSizing) {
-          return [true, 0];
-        }
-        return [true, value.toString().length];
-      } else if (value instanceof String) {
-        if (skipSizing) {
-          return [true, 0];
-        }
-        return [
-          true,
-          calculateStringSize(value.toString()) + JsonSize.Quote * 2,
         ];
       }
     } catch (_) {

--- a/src/json.ts
+++ b/src/json.ts
@@ -335,13 +335,12 @@ export function validateJsonAndGetSize(
         if (skipSizing) {
           return [true, 0];
         }
-        const jsonSerializedDate = value.toJSON();
         return [
           true,
           // Note: Invalid dates will serialize to null
-          jsonSerializedDate === null
+          isNaN(value.getDate())
             ? JsonSize.Null
-            : calculateStringSize(jsonSerializedDate) + JsonSize.Quote * 2,
+            : JsonSize.Date + JsonSize.Quote * 2,
         ];
       } else if (value instanceof Boolean) {
         if (skipSizing) {

--- a/src/json.ts
+++ b/src/json.ts
@@ -279,21 +279,21 @@ export function getJsonRpcIdValidator(options?: JsonRpcValidatorOptions) {
  *
  * This function assumes the encoding of the JSON is done in UTF-8.
  *
- * @param value - A potential JSON serializable value.
+ * @param value - Potential JSON serializable value.
  * @param skipSizing - Skip JSON size calculation (default: false).
- * @returns A tuple [isValid, plainTextSizeInBytes] containing a boolean that signals whether
+ * @returns Tuple [isValid, plainTextSizeInBytes] containing a boolean that signals whether
  * the value was serializable and a number of bytes that it will use when serialized to JSON.
  */
 export function getJsonSerializableInfo(
   value: unknown,
   skipSizing = false,
-): [boolean, number] {
+): [isValid: boolean, plainTextSizeInBytes: number] {
   if (value === undefined) {
     // Return zero for undefined, since these are omitted from JSON serialization
     return [true, 0];
   } else if (value === null) {
     // Return already specified constant size for null (special object)
-    return [true, skipSizing ? 0 : JsonSize.NULL];
+    return [true, skipSizing ? 0 : JsonSize.Null];
   }
 
   // Check and calculate sizes for basic types
@@ -302,13 +302,13 @@ export function getJsonSerializableInfo(
     case 'string':
       return [
         true,
-        skipSizing ? 0 : calculateStringSize(value) + JsonSize.QUOTE * 2,
+        skipSizing ? 0 : calculateStringSize(value) + JsonSize.Quote * 2,
       ];
     case 'boolean':
       if (skipSizing) {
         return [true, 0];
       }
-      return [true, value ? JsonSize.TRUE : JsonSize.FALSE];
+      return [true, value ? JsonSize.True : JsonSize.False];
     case 'number':
       return [true, skipSizing ? 0 : calculateNumberSize(value)];
   }
@@ -341,23 +341,23 @@ export function getJsonSerializableInfo(
           // If the size is 0, the value is undefined and undefined in an array
           // when serialized will be replaced with null
           if (!skipSizing && size === 0 && Array.isArray(value)) {
-            size = JsonSize.NULL;
+            size = JsonSize.Null;
           }
 
           // Objects will have be serialized with "key": value,
           // therefore we include the key in the calculation here
           const keySize = Array.isArray(value)
             ? 0
-            : key.length + JsonSize.COMMA + JsonSize.COLON * 2;
+            : key.length + JsonSize.Comma + JsonSize.Colon * 2;
 
-          const separator = idx < arr.length - 1 ? JsonSize.COMMA : 0;
+          const separator = idx < arr.length - 1 ? JsonSize.Comma : 0;
           // If the size is 0, that means the object is undefined and
           // the rest of the object structure will be omitted
           return size === 0 ? sum : sum + keySize + size + separator;
         },
         // Starts at 2 because the serialized JSON string data (plain text)
         // will minimally contain {}/[]
-        skipSizing ? 0 : JsonSize.WRAPPER * 2,
+        skipSizing ? 0 : JsonSize.Wrapper * 2,
       ),
     ];
   } catch (_) {

--- a/src/json.ts
+++ b/src/json.ts
@@ -313,6 +313,22 @@ export function getJsonSerializableInfo(
       return [true, skipSizing ? 0 : calculateNumberSize(value)];
   }
 
+  // Check if value is Date and handle it since Date is
+  // specific complex object that is JSON serializable
+  if (value instanceof Date) {
+    if (skipSizing) {
+      return [true, 0];
+    }
+    const jsonSerializedDate = value.toJSON();
+    return [
+      true,
+      // Note: Invalid dates will serialize to null
+      jsonSerializedDate === null
+        ? JsonSize.Null
+        : calculateStringSize(jsonSerializedDate) + JsonSize.Quote * 2,
+    ];
+  }
+
   // If object is not plain and cannot be serialized properly,
   // stop here and return false for serialization
   if (!isPlainObject(value) && !Array.isArray(value)) {

--- a/src/json.ts
+++ b/src/json.ts
@@ -266,3 +266,98 @@ export function getJsonRpcIdValidator(options?: JsonRpcValidatorOptions) {
   };
   return isValidJsonRpcId;
 }
+
+const NULL_LENGTH = 4; // null
+const COMMA_LENGTH = 1; // ,
+const WRAPPER_LENGTH = 1; // either [ ] { }
+const TRUE_LENGTH = 4; // true
+const FALSE_LENGTH = 5; // false
+const ZERO_LENGTH = 1; // 0
+const QUOTE_LENGTH = 1; // "
+const COLON_LENGTH = 1; // :
+
+/**
+ * Checks whether a value is JSON serializable and counts the total number
+ * of bytes needed to store the serialized version of the value.
+ *
+ * This function assumes the encoding of the JSON is done in UTF-8.
+ *
+ * @param value - A potential JSON serializable value.
+ * @returns A tuple containing a boolean that signals whether the value was serializable and
+ * a number of bytes that it will use when serialized to JSON.
+ */
+export function getJsonSerializableInfo(value: unknown): [boolean, number] {
+  if (value === undefined) {
+    return [true, 0];
+  } else if (value === null) {
+    return [true, NULL_LENGTH];
+  }
+
+  // eslint-disable-next-line default-case
+  switch (typeof value) {
+    case 'string':
+      // TODO: Check if character is ASCII (1B) or UTF-8 (2B)
+      return [true, value.length * 2 + QUOTE_LENGTH * 2];
+    case 'boolean':
+      return [true, value ? TRUE_LENGTH : FALSE_LENGTH];
+    case 'number':
+      return [
+        true,
+        // Check number of digits since all digits are 1 byte
+        value === 0 ? ZERO_LENGTH : Math.floor(Math.log10(value) + 1),
+      ];
+  }
+
+  if (!isPlainObject(value) && !Array.isArray(value)) {
+    return [false, 0];
+  }
+
+  try {
+    return [
+      true,
+      Object.entries(value).reduce(
+        (sum, [key, nestedValue], idx, arr) => {
+          const [valid, size] = getJsonSerializableInfo(nestedValue);
+          if (!valid) {
+            throw new Error();
+          }
+          // Objects will have be serialized with "key": value, therefore we include the key in the calculation here
+          const keySize = Array.isArray(value)
+            ? 0
+            : key.length + COMMA_LENGTH + COLON_LENGTH * 2;
+          const separator = idx < arr.length - 1 ? COMMA_LENGTH : 0;
+          return sum + keySize + size + separator;
+        },
+        // Starts at 2 because the string will minimally contain {}/[]
+        WRAPPER_LENGTH * 2,
+      ),
+    ];
+  } catch (_) {
+    return [false, 0];
+  }
+}
+
+export type PlainObject = Record<number | string | symbol, unknown>;
+
+/**
+ * Check if the value is plain object.
+ *
+ * @param value - Value to be checked.
+ * @returns Boolean.
+ */
+export function isPlainObject(value: unknown): value is PlainObject {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  try {
+    let proto = value;
+    while (Object.getPrototypeOf(proto) !== null) {
+      proto = Object.getPrototypeOf(proto);
+    }
+
+    return Object.getPrototypeOf(value) === proto;
+  } catch (_) {
+    return false;
+  }
+}

--- a/src/json.ts
+++ b/src/json.ts
@@ -332,6 +332,10 @@ export function getJsonSerializableInfo(
             throw new Error();
           }
 
+          if (skipSizing) {
+            return 0;
+          }
+
           // If the size is 0, the value is undefined and undefined in an array
           // when serialized will be replaced with null
           if (!skipSizing && size === 0 && Array.isArray(value)) {
@@ -340,18 +344,11 @@ export function getJsonSerializableInfo(
 
           // Objects will have be serialized with "key": value,
           // therefore we include the key in the calculation here
-          let keySize: any;
-          if (skipSizing) {
-            keySize = 0;
-          } else {
-            keySize = Array.isArray(value)
-              ? 0
-              : key.length + JsonSize.COMMA + JsonSize.COLON * 2;
-          }
-          let separator = 0;
-          if (!skipSizing) {
-            separator = idx < arr.length - 1 ? JsonSize.COMMA : 0;
-          }
+          const keySize = Array.isArray(value)
+            ? 0
+            : key.length + JsonSize.COMMA + JsonSize.COLON * 2;
+
+          const separator = idx < arr.length - 1 ? JsonSize.COMMA : 0;
           // If the size is 0, that means the object is undefined and
           // the rest of the object structure will be omitted
           return size === 0 ? sum : sum + keySize + size + separator;

--- a/src/json.ts
+++ b/src/json.ts
@@ -340,6 +340,11 @@ export function getJsonSerializableInfo(
         return [true, 0];
       }
       return [true, value.toString().length];
+    } else if (value instanceof String) {
+      if (skipSizing) {
+        return [true, 0];
+      }
+      return [true, calculateStringSize(value.toString()) + JsonSize.Quote * 2];
     }
   } catch (_) {
     return [false, 0];

--- a/src/json.ts
+++ b/src/json.ts
@@ -277,204 +277,161 @@ export function getJsonRpcIdValidator(options?: JsonRpcValidatorOptions) {
  * Checks whether a value is JSON serializable and counts the total number
  * of bytes needed to store the serialized version of the value.
  *
- * Important note: This function will not check for circular references.
- * For circular reference check support, use validateJsonAndGetSize function.
- *
- * This function assumes the encoding of the JSON is done in UTF-8.
- *
- * @param value - Potential JSON serializable value.
- * @param skipSizing - Skip JSON size calculation (default: false).
- * @returns Tuple [isValid, plainTextSizeInBytes] containing a boolean that signals whether
- * the value was serializable and a number of bytes that it will use when serialized to JSON.
- */
-export function getJsonSerializableInfo(
-  value: unknown,
-  skipSizing = false,
-): [isValid: boolean, plainTextSizeInBytes: number] {
-  if (value === undefined) {
-    // Return zero for undefined, since these are omitted from JSON serialization
-    return [true, 0];
-  } else if (value === null) {
-    // Return already specified constant size for null (special object)
-    return [true, skipSizing ? 0 : JsonSize.Null];
-  }
-
-  // Check and calculate sizes for basic types
-  // eslint-disable-next-line default-case
-  switch (typeof value) {
-    case 'function':
-      return [false, 0];
-    case 'string':
-      return [
-        true,
-        skipSizing ? 0 : calculateStringSize(value) + JsonSize.Quote * 2,
-      ];
-    case 'boolean':
-      if (skipSizing) {
-        return [true, 0];
-      }
-      return [true, value ? JsonSize.True : JsonSize.False];
-    case 'number':
-      return [true, skipSizing ? 0 : calculateNumberSize(value)];
-  }
-
-  // Handle specific complex objects that can be serialized properly
-  try {
-    if (value instanceof Date) {
-      if (skipSizing) {
-        return [true, 0];
-      }
-      const jsonSerializedDate = value.toJSON();
-      return [
-        true,
-        // Note: Invalid dates will serialize to null
-        jsonSerializedDate === null
-          ? JsonSize.Null
-          : calculateStringSize(jsonSerializedDate) + JsonSize.Quote * 2,
-      ];
-    } else if (value instanceof Boolean) {
-      if (skipSizing) {
-        return [true, 0];
-      }
-      // eslint-disable-next-line eqeqeq
-      return [true, value == true ? JsonSize.True : JsonSize.False];
-    } else if (value instanceof Number) {
-      if (skipSizing) {
-        return [true, 0];
-      }
-      return [true, value.toString().length];
-    } else if (value instanceof String) {
-      if (skipSizing) {
-        return [true, 0];
-      }
-      return [true, calculateStringSize(value.toString()) + JsonSize.Quote * 2];
-    }
-  } catch (_) {
-    return [false, 0];
-  }
-
-  // If object is not plain and cannot be serialized properly,
-  // stop here and return false for serialization
-  if (!isPlainObject(value) && !Array.isArray(value)) {
-    return [false, 0];
-  }
-
-  // Continue object decomposition
-  try {
-    return [
-      true,
-      Object.entries(value).reduce(
-        (sum, [key, nestedValue], idx, arr) => {
-          // Recursively process next nested object or primitive type
-          // eslint-disable-next-line prefer-const
-          let [valid, size] = getJsonSerializableInfo(nestedValue, skipSizing);
-          if (!valid) {
-            throw new Error(
-              'JSON validation did not pass. Validation process stopped.',
-            );
-          }
-
-          if (skipSizing) {
-            return 0;
-          }
-
-          // If the size is 0, the value is undefined and undefined in an array
-          // when serialized will be replaced with null
-          if (size === 0 && Array.isArray(value)) {
-            size = JsonSize.Null;
-          }
-
-          // If the size is 0, that means the object is undefined and
-          // the rest of the object structure will be omitted
-          if (size === 0) {
-            return sum;
-          }
-
-          // Objects will have be serialized with "key": value,
-          // therefore we include the key in the calculation here
-          const keySize = Array.isArray(value)
-            ? 0
-            : key.length + JsonSize.Comma + JsonSize.Colon * 2;
-
-          const separator = idx < arr.length - 1 ? JsonSize.Comma : 0;
-
-          return sum + keySize + size + separator;
-        },
-        // Starts at 2 because the serialized JSON string data (plain text)
-        // will minimally contain {}/[]
-        skipSizing ? 0 : JsonSize.Wrapper * 2,
-      ),
-    ];
-  } catch (_) {
-    return [false, 0];
-  }
-}
-
-/**
- * Check for circular structures (e.g. object referencing itself).
- *
- * @param objectToBeChecked - Object that potentially can have circular references.
- * @returns True if circular structure is detected, false otherwise.
- */
-export function isObjectContainingCircularStructure(
-  objectToBeChecked: unknown,
-): boolean {
-  if (typeof objectToBeChecked !== 'object') {
-    return false;
-  }
-  const seenObjects: unknown[] = [];
-
-  /**
-   * Internal function for detection of circular structures.
-   *
-   * @param obj - Object that needs to be checked.
-   * @returns True if circular structure is detected, false otherwise.
-   */
-  function detect(obj: unknown): boolean {
-    if (obj && typeof obj === 'object') {
-      if (seenObjects.indexOf(obj) !== -1) {
-        return true;
-      }
-      seenObjects.push(obj);
-      return Boolean(
-        Object.keys(obj).reduce((result, key) => {
-          if (result) {
-            return true;
-          }
-
-          if (typeof obj[key as keyof unknown] !== 'object') {
-            return false;
-          }
-
-          return detect(obj[key as keyof unknown]);
-        }, false),
-      );
-    }
-    return false;
-  }
-
-  return detect(objectToBeChecked);
-}
-
-/**
- * Checks whether a value is JSON serializable and counts the total number
- * of bytes needed to store the serialized version of the value.
- *
- * Note: This is a wrapper function that will do check for circular structures.
- * This function assumes the encoding of the JSON is done in UTF-8.
- *
- * @param value - Potential JSON serializable value.
- * @param skipSizing - Skip JSON size calculation (default: false).
+ * @param jsObject - Potential JSON serializable object.
+ * @param skipSizingProcess - Skip JSON size calculation (default: false).
  * @returns Tuple [isValid, plainTextSizeInBytes] containing a boolean that signals whether
  * the value was serializable and a number of bytes that it will use when serialized to JSON.
  */
 export function validateJsonAndGetSize(
-  value: unknown,
-  skipSizing = false,
+  jsObject: unknown,
+  skipSizingProcess = false,
 ): [isValid: boolean, plainTextSizeInBytes: number] {
-  if (isObjectContainingCircularStructure(value)) {
-    return [false, 0];
+  const seenObjects: unknown[] = [];
+  /**
+   * Checks whether a value is JSON serializable and counts the total number
+   * of bytes needed to store the serialized version of the value.
+   *
+   * This function assumes the encoding of the JSON is done in UTF-8.
+   *
+   * @param value - Potential JSON serializable value.
+   * @param skipSizing - Skip JSON size calculation (default: false).
+   * @returns Tuple [isValid, plainTextSizeInBytes] containing a boolean that signals whether
+   * the value was serializable and a number of bytes that it will use when serialized to JSON.
+   */
+  function getJsonSerializableInfo(
+    value: unknown,
+    skipSizing: boolean,
+  ): [isValid: boolean, plainTextSizeInBytes: number] {
+    if (value === undefined) {
+      // Return zero for undefined, since these are omitted from JSON serialization
+      return [true, 0];
+    } else if (value === null) {
+      // Return already specified constant size for null (special object)
+      return [true, skipSizing ? 0 : JsonSize.Null];
+    }
+
+    // Check and calculate sizes for basic types
+    // eslint-disable-next-line default-case
+    switch (typeof value) {
+      case 'function':
+        return [false, 0];
+      case 'string':
+        return [
+          true,
+          skipSizing ? 0 : calculateStringSize(value) + JsonSize.Quote * 2,
+        ];
+      case 'boolean':
+        if (skipSizing) {
+          return [true, 0];
+        }
+        return [true, value ? JsonSize.True : JsonSize.False];
+      case 'number':
+        return [true, skipSizing ? 0 : calculateNumberSize(value)];
+    }
+
+    // Handle specific complex objects that can be serialized properly
+    try {
+      if (value instanceof Date) {
+        if (skipSizing) {
+          return [true, 0];
+        }
+        const jsonSerializedDate = value.toJSON();
+        return [
+          true,
+          // Note: Invalid dates will serialize to null
+          jsonSerializedDate === null
+            ? JsonSize.Null
+            : calculateStringSize(jsonSerializedDate) + JsonSize.Quote * 2,
+        ];
+      } else if (value instanceof Boolean) {
+        if (skipSizing) {
+          return [true, 0];
+        }
+        // eslint-disable-next-line eqeqeq
+        return [true, value == true ? JsonSize.True : JsonSize.False];
+      } else if (value instanceof Number) {
+        if (skipSizing) {
+          return [true, 0];
+        }
+        return [true, value.toString().length];
+      } else if (value instanceof String) {
+        if (skipSizing) {
+          return [true, 0];
+        }
+        return [
+          true,
+          calculateStringSize(value.toString()) + JsonSize.Quote * 2,
+        ];
+      }
+    } catch (_) {
+      return [false, 0];
+    }
+
+    // If object is not plain and cannot be serialized properly,
+    // stop here and return false for serialization
+    if (!isPlainObject(value) && !Array.isArray(value)) {
+      return [false, 0];
+    }
+
+    // Handle circular objects
+    if (seenObjects.indexOf(value) !== -1) {
+      return [false, 0];
+    }
+    seenObjects.push(value);
+
+    // Continue object decomposition
+    try {
+      return [
+        true,
+        Object.entries(value).reduce(
+          (sum, [key, nestedValue], idx, arr) => {
+            // Recursively process next nested object or primitive type
+            // eslint-disable-next-line prefer-const
+            let [valid, size] = getJsonSerializableInfo(
+              nestedValue,
+              skipSizing,
+            );
+            if (!valid) {
+              throw new Error(
+                'JSON validation did not pass. Validation process stopped.',
+              );
+            }
+
+            if (skipSizing) {
+              return 0;
+            }
+
+            // If the size is 0, the value is undefined and undefined in an array
+            // when serialized will be replaced with null
+            if (size === 0 && Array.isArray(value)) {
+              size = JsonSize.Null;
+            }
+
+            // If the size is 0, that means the object is undefined and
+            // the rest of the object structure will be omitted
+            if (size === 0) {
+              return sum;
+            }
+
+            // Objects will have be serialized with "key": value,
+            // therefore we include the key in the calculation here
+            const keySize = Array.isArray(value)
+              ? 0
+              : key.length + JsonSize.Comma + JsonSize.Colon * 2;
+
+            const separator = idx < arr.length - 1 ? JsonSize.Comma : 0;
+
+            return sum + keySize + size + separator;
+          },
+          // Starts at 2 because the serialized JSON string data (plain text)
+          // will minimally contain {}/[]
+          skipSizing ? 0 : JsonSize.Wrapper * 2,
+        ),
+      ];
+    } catch (_) {
+      return [false, 0];
+    }
   }
 
-  return getJsonSerializableInfo(value, skipSizing);
+  return getJsonSerializableInfo(jsObject, skipSizingProcess);
 }

--- a/src/json.ts
+++ b/src/json.ts
@@ -340,8 +340,14 @@ export function getJsonSerializableInfo(
 
           // If the size is 0, the value is undefined and undefined in an array
           // when serialized will be replaced with null
-          if (!skipSizing && size === 0 && Array.isArray(value)) {
+          if (size === 0 && Array.isArray(value)) {
             size = JsonSize.Null;
+          }
+
+          // If the size is 0, that means the object is undefined and
+          // the rest of the object structure will be omitted
+          if (size === 0) {
+            return sum;
           }
 
           // Objects will have be serialized with "key": value,
@@ -351,11 +357,7 @@ export function getJsonSerializableInfo(
             : key.length + JsonSize.Comma + JsonSize.Colon * 2;
 
           const separator = idx < arr.length - 1 ? JsonSize.Comma : 0;
-          // If the size is 0, that means the object is undefined and
-          // the rest of the object structure will be omitted
-          if (size === 0) {
-            return sum;
-          }
+
           return sum + keySize + size + separator;
         },
         // Starts at 2 because the serialized JSON string data (plain text)

--- a/src/misc.test.ts
+++ b/src/misc.test.ts
@@ -175,6 +175,11 @@ describe('miscellaneous', () => {
       const str = 'ašbđcćdčež';
       expect(calculateStringSize(str)).toBe(15);
     });
+
+    it('should return 10 for a size of special characters', () => {
+      const str = '"\\\n\r\t';
+      expect(calculateStringSize(str)).toBe(10);
+    });
   });
 
   describe('calculateNumberSize', () => {

--- a/src/misc.test.ts
+++ b/src/misc.test.ts
@@ -8,7 +8,6 @@ import {
   calculateNumberSize,
   isASCII,
   calculateStringSize,
-  getNumberOfDecimals,
 } from '.';
 
 describe('miscellaneous', () => {
@@ -195,8 +194,10 @@ describe('miscellaneous', () => {
       expect(calculateNumberSize(-123.45)).toBe(7);
     });
 
-    it('should return 12 for a "0.0000000005" number size', () => {
-      expect(calculateNumberSize(0.0000000005)).toBe(12);
+    it('should return 5 for a "0.0000000005" number size', () => {
+      // Because the number provided here will be changed to exponential notation
+      // 5e-10 by default
+      expect(calculateNumberSize(0.0000000005)).toBe(5);
     });
 
     it('should return 16 for a "9007199254740991" number size', () => {
@@ -210,39 +211,9 @@ describe('miscellaneous', () => {
     it('should return 1 for a "0" number size', () => {
       expect(calculateNumberSize(0)).toBe(1);
     });
-  });
 
-  describe('getNumberOfDecimals', () => {
-    it('should return 0 for number of decimals of "100"', () => {
-      expect(getNumberOfDecimals(100)).toBe(0);
-    });
-
-    it('should return 3 for number of decimals of "0.333"', () => {
-      expect(getNumberOfDecimals(0.333)).toBe(3);
-    });
-
-    it('should return 5 for number of decimals of "-100.88888"', () => {
-      expect(getNumberOfDecimals(-100.88888)).toBe(5);
-    });
-
-    it('should return 8 for number of decimals of "100000.00000008"', () => {
-      expect(getNumberOfDecimals(100000.00000008)).toBe(8);
-    });
-
-    it('should return 11 for number of decimals of "-0.00000000009"', () => {
-      expect(getNumberOfDecimals(-0.00000000009)).toBe(11);
-    });
-
-    it('should return 12 for number of decimals of "0.000000000001"', () => {
-      expect(getNumberOfDecimals(0.000000000001)).toBe(12);
-    });
-
-    it('should return 6 for number of decimals of "5e-6"', () => {
-      expect(getNumberOfDecimals(5e-6)).toBe(6);
-    });
-
-    it('should return 6 for number of decimals of "-5e-11"', () => {
-      expect(getNumberOfDecimals(-5e-11)).toBe(11);
+    it('should return 15 for a "100000.00000008" number size', () => {
+      expect(calculateNumberSize(100000.00000008)).toBe(15);
     });
   });
 });

--- a/src/misc.test.ts
+++ b/src/misc.test.ts
@@ -159,12 +159,12 @@ describe('miscellaneous', () => {
   });
 
   describe('calculateStringSize', () => {
-    it('should return 94 for a size of ASCII string', () => {
+    it('should return 96 for a size of ASCII string', () => {
       const str =
         '!"#$%&\'()*+,-./0123456789:;<=>?' +
         '@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]' +
         '^_`abcdefghijklmnopqrstuvwxyz{|}~';
-      expect(calculateStringSize(str)).toBe(94);
+      expect(calculateStringSize(str)).toBe(96);
     });
 
     it('should return 10 for a size of UTF8 string', () => {

--- a/src/misc.test.ts
+++ b/src/misc.test.ts
@@ -7,6 +7,8 @@ import {
   isPlainObject,
   calculateNumberSize,
   isASCII,
+  calculateStringSize,
+  getNumberOfDecimals,
 } from '.';
 
 describe('miscellaneous', () => {
@@ -135,6 +137,15 @@ describe('miscellaneous', () => {
 
       expect(isPlainObject(someSet)).toBe(false);
     });
+
+    it('should return false if an exception is thrown', () => {
+      const someObject = { something: 'anything' };
+      jest.spyOn(Object, 'getPrototypeOf').mockImplementationOnce(() => {
+        throw new Error();
+      });
+
+      expect(isPlainObject(someObject)).toBe(false);
+    });
   });
 
   describe('isASCII', () => {
@@ -144,6 +155,26 @@ describe('miscellaneous', () => {
 
     it('should return false for "Š" which is not the ASCII character', () => {
       expect(isASCII('Š')).toBe(false);
+    });
+  });
+
+  describe('calculateStringSize', () => {
+    it('should return 94 for a size of ASCII string', () => {
+      const str =
+        '!"#$%&\'()*+,-./0123456789:;<=>?' +
+        '@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]' +
+        '^_`abcdefghijklmnopqrstuvwxyz{|}~';
+      expect(calculateStringSize(str)).toBe(94);
+    });
+
+    it('should return 10 for a size of UTF8 string', () => {
+      const str = 'šđćčž';
+      expect(calculateStringSize(str)).toBe(10);
+    });
+
+    it('should return 15 for a size of mixed, ASCII and UTF8 string', () => {
+      const str = 'ašbđcćdčež';
+      expect(calculateStringSize(str)).toBe(15);
     });
   });
 
@@ -174,6 +205,44 @@ describe('miscellaneous', () => {
 
     it('should return 17 for a "-9007199254740991" number size', () => {
       expect(calculateNumberSize(-9007199254740991)).toBe(17);
+    });
+
+    it('should return 1 for a "0" number size', () => {
+      expect(calculateNumberSize(0)).toBe(1);
+    });
+  });
+
+  describe('getNumberOfDecimals', () => {
+    it('should return 0 for number of decimals of "100"', () => {
+      expect(getNumberOfDecimals(100)).toBe(0);
+    });
+
+    it('should return 3 for number of decimals of "0.333"', () => {
+      expect(getNumberOfDecimals(0.333)).toBe(3);
+    });
+
+    it('should return 5 for number of decimals of "-100.88888"', () => {
+      expect(getNumberOfDecimals(-100.88888)).toBe(5);
+    });
+
+    it('should return 8 for number of decimals of "100000.00000008"', () => {
+      expect(getNumberOfDecimals(100000.00000008)).toBe(8);
+    });
+
+    it('should return 11 for number of decimals of "-0.00000000009"', () => {
+      expect(getNumberOfDecimals(-0.00000000009)).toBe(11);
+    });
+
+    it('should return 12 for number of decimals of "0.000000000001"', () => {
+      expect(getNumberOfDecimals(0.000000000001)).toBe(12);
+    });
+
+    it('should return 6 for number of decimals of "5e-6"', () => {
+      expect(getNumberOfDecimals(5e-6)).toBe(6);
+    });
+
+    it('should return 6 for number of decimals of "-5e-11"', () => {
+      expect(getNumberOfDecimals(-5e-11)).toBe(11);
     });
   });
 });

--- a/src/misc.test.ts
+++ b/src/misc.test.ts
@@ -4,6 +4,9 @@ import {
   isObject,
   hasProperty,
   RuntimeObject,
+  isPlainObject,
+  calculateNumberSize,
+  isASCII,
 } from '.';
 
 describe('miscellaneous', () => {
@@ -106,6 +109,71 @@ describe('miscellaneous', () => {
       ] as any[]).forEach(([objectValue, property]) => {
         expect(hasProperty(objectValue, property)).toBe(false);
       });
+    });
+  });
+
+  describe('isPlainObject', () => {
+    it('should return true for a plain object', () => {
+      const somePlainObject = {
+        someKey: 'someValue',
+      };
+
+      expect(isPlainObject(somePlainObject)).toBe(true);
+    });
+
+    it('should return false if function is passed', () => {
+      const someFunction = (someArg: string) => {
+        return someArg;
+      };
+
+      expect(isPlainObject(someFunction)).toBe(false);
+    });
+
+    it('should return false if Set object is passed', () => {
+      const someSet = new Set();
+      someSet.add('something');
+
+      expect(isPlainObject(someSet)).toBe(false);
+    });
+  });
+
+  describe('isASCII', () => {
+    it('should return true for "A" which is the ASCII character', () => {
+      expect(isASCII('A')).toBe(true);
+    });
+
+    it('should return false for "Š" which is not the ASCII character', () => {
+      expect(isASCII('Š')).toBe(false);
+    });
+  });
+
+  describe('calculateNumberSize', () => {
+    it('should return 3 for a "100" number size', () => {
+      expect(calculateNumberSize(100)).toBe(3);
+    });
+
+    it('should return 4 for a "-100" number size', () => {
+      expect(calculateNumberSize(-100)).toBe(4);
+    });
+
+    it('should return 4 for a "-0.3" number size', () => {
+      expect(calculateNumberSize(-0.3)).toBe(4);
+    });
+
+    it('should return 7 for a "-123.45" number size', () => {
+      expect(calculateNumberSize(-123.45)).toBe(7);
+    });
+
+    it('should return 12 for a "0.0000000005" number size', () => {
+      expect(calculateNumberSize(0.0000000005)).toBe(12);
+    });
+
+    it('should return 16 for a "9007199254740991" number size', () => {
+      expect(calculateNumberSize(9007199254740991)).toBe(16);
+    });
+
+    it('should return 17 for a "-9007199254740991" number size', () => {
+      expect(calculateNumberSize(-9007199254740991)).toBe(17);
     });
   });
 });

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -162,9 +162,8 @@ export function calculateStringSize(value: string) {
 
   // Detect characters that need backslash escape
   const re = /"|\\|\n|\r|\t/gu;
-  size += (value.match(re) || []).length;
 
-  return size;
+  return size + (value.match(re) || []).length;
 }
 
 /**

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -219,16 +219,11 @@ export function getNumberOfDecimals(value: number): number {
     return 0;
   }
 
-  const str = value.toString();
+  const str = Math.abs(value).toString();
 
   if (str.indexOf('e-') > -1) {
     return parseInt(str.split('e-')[1], 10);
   }
 
-  if (str.indexOf('.') !== -1 && str.indexOf('-') !== -1) {
-    return str.split('-')[1].length;
-  } else if (str.indexOf('.') !== -1) {
-    return str.split('.')[1].length;
-  }
-  return str.split('-')[1].length;
+  return str.split('.')[1].length;
 }

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -174,60 +174,8 @@ export function calculateStringSize(value: string) {
  * @returns Number of bytes used to store whole number in JSON.
  */
 export function calculateNumberSize(value: number): number {
-  if (value === 0) {
-    return JsonSize.ZERO;
+  if (value?.toString().length) {
+    return value.toString().length;
   }
-
-  let size = 0;
-  // Work with absolute (positive) numbers only
-  let absNum = value;
-  if (value < 0) {
-    absNum = Math.abs(value);
-    // Initially, count on a sign of a number (-)
-    size += 1;
-  }
-
-  // If absolute value of a number is greater than 1 and is a whole number,
-  // then perform the fastest operation to calculate its size
-  // Portion of numbers passed to this function will fall into this category,
-  // so it will not be required to do to string conversion and manipulation.
-  if (absNum - Math.floor(absNum) === 0) {
-    size += Math.floor(Math.log10(absNum) + 1);
-    return size;
-  }
-
-  // Work with decimal numbers
-  // First calculate the size of the whole part of a number
-  if (absNum >= 1) {
-    size += Math.floor(Math.log10(absNum) + 1);
-  } else {
-    // Because absolute value is less than 1, count size of a zero digit
-    size += JsonSize.ZERO;
-  }
-  // Then add the dot '.' size
-  size += JsonSize.DOT;
-  // Then calculate the number of decimal places
-  size += getNumberOfDecimals(absNum);
-
-  return size;
-}
-
-/**
- * Calculate the number of decimals for a given number.
- *
- * @param value - Decimal number.
- * @returns Number of decimals.
- */
-export function getNumberOfDecimals(value: number): number {
-  if (Math.floor(value) === value) {
-    return 0;
-  }
-
-  const str = Math.abs(value).toString();
-
-  if (str.indexOf('e-') > -1) {
-    return parseInt(str.split('e-')[1], 10);
-  }
-
-  return str.split('.')[1].length;
+  return 0;
 }

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -134,14 +134,13 @@ export function isPlainObject(value: unknown): value is PlainObject {
 }
 
 /**
- * Check if character or string is ASCII.
+ * Check if character is ASCII.
  *
- * @param value - String or character.
- * @returns Boolean, true if value is ASCII, false if not.
+ * @param character - Character.
+ * @returns Boolean, true if character code is ASCII, false if not.
  */
-export function isASCII(value: string) {
-  // eslint-disable-next-line no-control-regex,require-unicode-regexp
-  return /^[\x00-\x7F]*$/.test(value);
+export function isASCII(character: string) {
+  return character.charCodeAt(0) <= 127;
 }
 
 /**

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -161,7 +161,7 @@ export function calculateStringSize(value: string) {
   }
 
   // Detect characters that need backslash escape
-  const re = /\\|'/gu;
+  const re = /"|\\|\n|\r|\t/gu;
   size += (value.match(re) || []).length;
 
   return size;

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -106,6 +106,7 @@ export enum JsonSize {
   False = 5,
   Quote = 1,
   Colon = 1,
+  Date = 24,
 }
 
 /**

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -162,7 +162,7 @@ export function calculateStringSize(value: string) {
 
   // Detect characters that need backslash escape
   const re = /\\|'/gu;
-  size += ((value || '').match(re) || []).length;
+  size += (value.match(re) || []).length;
 
   return size;
 }
@@ -174,8 +174,5 @@ export function calculateStringSize(value: string) {
  * @returns Number of bytes used to store whole number in JSON.
  */
 export function calculateNumberSize(value: number): number {
-  if (value?.toString().length) {
-    return value.toString().length;
-  }
-  return 0;
+  return value.toString().length;
 }

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -160,6 +160,10 @@ export function calculateStringSize(value: string) {
     }
   }
 
+  // Detect characters that need backslash escape
+  const re = /\\|'/gu;
+  size += ((value || '').match(re) || []).length;
+
   return size;
 }
 

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -114,7 +114,8 @@ export enum JsonSize {
  * Check if the value is plain object.
  *
  * @param value - Value to be checked.
- * @returns Boolean.
+ * @returns True if an object is the plain JavaScript object,
+ * false if the object is not plain (e.g. function).
  */
 export function isPlainObject(value: unknown): value is PlainObject {
   if (typeof value !== 'object' || value === null) {
@@ -137,7 +138,7 @@ export function isPlainObject(value: unknown): value is PlainObject {
  * Check if character is ASCII.
  *
  * @param character - Character.
- * @returns Boolean, true if character code is ASCII, false if not.
+ * @returns True if a character code is ASCII, false if not.
  */
 export function isASCII(character: string) {
   return character.charCodeAt(0) <= 127;
@@ -162,7 +163,7 @@ export function calculateStringSize(value: string) {
   // Detect characters that need backslash escape
   const re = /"|\\|\n|\r|\t/gu;
 
-  return size + (value.match(re) || []).length;
+  return size + (value.match(re) ?? []).length;
 }
 
 /**

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -99,15 +99,13 @@ export type PlainObject = Record<number | string | symbol, unknown>;
  * Predefined sizes (in Bytes) of specific parts of JSON structure.
  */
 export enum JsonSize {
-  NULL = 4,
-  COMMA = 1,
-  WRAPPER = 1,
-  TRUE = 4,
-  FALSE = 5,
-  ZERO = 1,
-  QUOTE = 1,
-  COLON = 1,
-  DOT = 1,
+  Null = 4,
+  Comma = 1,
+  Wrapper = 1,
+  True = 4,
+  False = 5,
+  Quote = 1,
+  Colon = 1,
 }
 
 /**
@@ -150,15 +148,13 @@ export function isASCII(character: string) {
  * @param value - String value to calculate size.
  * @returns Number of bytes used to store whole string value.
  */
-export function calculateStringSize(value: string) {
-  let size = 0;
-  for (const character of value) {
+export function calculateStringSize(value: string): number {
+  const size = value.split('').reduce((total, character) => {
     if (isASCII(character)) {
-      size += 1;
-    } else {
-      size += 2;
+      return total + 1;
     }
-  }
+    return total + 2;
+  }, 0);
 
   // Detect characters that need backslash escape
   const re = /"|\\|\n|\r|\t/gu;

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -109,6 +109,11 @@ export enum JsonSize {
 }
 
 /**
+ * Regular expression with pattern matching for (special) escaped characters.
+ */
+export const ESCAPE_CHARACTERS_REGEXP = /"|\\|\n|\r|\t/gu;
+
+/**
  * Check if the value is plain object.
  *
  * @param value - Value to be checked.
@@ -156,10 +161,8 @@ export function calculateStringSize(value: string): number {
     return total + 2;
   }, 0);
 
-  // Detect characters that need backslash escape
-  const re = /"|\\|\n|\r|\t/gu;
-
-  return size + (value.match(re) ?? []).length;
+  // Also detect characters that need backslash escape
+  return size + (value.match(ESCAPE_CHARACTERS_REGEXP) ?? []).length;
 }
 
 /**

--- a/src/test.data.ts
+++ b/src/test.data.ts
@@ -75,6 +75,11 @@ export const complexObject = {
           t: true,
           f: false,
         },
+        dates: {
+          someDate: new Date(),
+          someOther: new Date(2022, 0, 2, 15, 4, 5),
+          invalidDate: new Date('bad-date-format'),
+        },
       },
     },
   },

--- a/src/test.data.ts
+++ b/src/test.data.ts
@@ -48,6 +48,7 @@ export const complexObject = {
           '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~',
         utf8: 'šđćčžЀЂЇЄЖФћΣΩδλ',
         mixed: 'ABCDEFGHIJ KLMNOPQRST UVWXYZšđćč žЀЂЇЄЖФћΣΩδλ',
+        specialCharacters: '"\\\n\r\t',
       },
       specialObjectsTypesAndValues: {
         t: [true, true, true],

--- a/src/test.data.ts
+++ b/src/test.data.ts
@@ -1,0 +1,123 @@
+export const complexObject = {
+  data: {
+    account: {
+      __typename: 'Account',
+      registrations: [
+        {
+          __typename: 'Registration',
+          domain: {
+            __typename: 'Domain',
+            isMigrated: true,
+            labelName: 'mycrypto',
+            labelhash:
+              '0x9a781ca0d227debc3ee76d547c960b0803a6c9f58c6d3b4722f12ede7e6ef7c9',
+            name: 'mycrypto.eth',
+            parent: { __typename: 'Domain', name: 'eth' },
+          },
+          expiryDate: '1754111315',
+        },
+      ],
+    },
+    moreComplexity: {
+      numbers: [
+        -5e-11,
+        5e-9,
+        0.000000000001,
+        -0.00000000009,
+        100000.00000008,
+        -100.88888,
+        0.333,
+        1000000000000,
+      ],
+      moreNestedObjects: {
+        nestedAgain: {
+          nestedAgain: {
+            andAgain: {
+              andAgain: {
+                value: true,
+                again: {
+                  value: false,
+                },
+              },
+            },
+          },
+        },
+      },
+      differentEncodings: {
+        ascii:
+          '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~',
+        utf8: 'šđćčžЀЂЇЄЖФћΣΩδλ',
+        mixed: 'ABCDEFGHIJ KLMNOPQRST UVWXYZšđćč žЀЂЇЄЖФћΣΩδλ',
+      },
+      specialObjectsTypesAndValues: {
+        t: [true, true, true],
+        f: [false, false, false],
+        nulls: [null, null, null],
+        undef: undefined,
+        mixed: [
+          null,
+          undefined,
+          null,
+          undefined,
+          null,
+          true,
+          null,
+          false,
+          null,
+          undefined,
+        ],
+        inObject: {
+          valueOne: null,
+          valueTwo: undefined,
+          t: true,
+          f: false,
+        },
+      },
+    },
+  },
+};
+
+export const nonSerializableNestedObject = {
+  levelOne: {
+    levelTwo: {
+      levelThree: {
+        levelFour: {
+          levelFive: new Set(),
+        },
+      },
+    },
+  },
+};
+
+export const arrayOfDifferentKindsOfNumbers = [
+  -5e-11,
+  5e-9,
+  0.000000000001,
+  -0.00000000009,
+  100000.00000008,
+  -100.88888,
+  0.333,
+  1000000000000,
+];
+
+export const arrayOfMixedSpecialObjects = [
+  null,
+  undefined,
+  null,
+  undefined,
+  undefined,
+  undefined,
+  null,
+  null,
+  null,
+  undefined,
+];
+
+export const objectMixedWithUndefinedValues = {
+  a: undefined,
+  b: 'b',
+  c: undefined,
+  d: 'd',
+  e: undefined,
+  f: 'f',
+};

--- a/src/test.data.ts
+++ b/src/test.data.ts
@@ -49,6 +49,8 @@ export const complexObject = {
         utf8: 'šđćčžЀЂЇЄЖФћΣΩδλ',
         mixed: 'ABCDEFGHIJ KLMNOPQRST UVWXYZšđćč žЀЂЇЄЖФћΣΩδλ',
         specialCharacters: '"\\\n\r\t',
+        stringWithSpecialEscapedCharacters:
+          "this\nis\nsome\"'string\r\nwith\tspecial\\escaped\tcharacters'",
       },
       specialObjectsTypesAndValues: {
         t: [true, true, true],

--- a/src/test.data.ts
+++ b/src/test.data.ts
@@ -90,7 +90,9 @@ export const nonSerializableNestedObject = {
     levelTwo: {
       levelThree: {
         levelFour: {
-          levelFive: new Set(),
+          levelFive: () => {
+            return 'anything';
+          },
         },
       },
     },


### PR DESCRIPTION
This PR will add utility functions to handle limits and validation of JSON storage used by Snaps.

_This is still work in progress._

The main goal of this PR is to implement the following function:
```javascript
export function validateJsonAndGetSize(
  jsObject: unknown,
  skipSizingProcess = false,
): [isValid: boolean, plainTextSizeInBytes: number]
```
This function has two capabilities:
1. Validate JavaScript object serialization capabilities (validate if JavaScript object can be serialized to JSON by using `JSON.stringify(...)`)
2. Calculate the potential size in Bytes after JavaScript object is serialized to plain text in JSON format.

Size calculation can be skipped by setting `skipSizingProcess=true` in which case only the validation process will be done and `0` will be returned for a size.

Fixes https://app.zenhub.com/workspaces/snaps-platform-615b3a7c08d2b20015eb6c4e/issues/metamask/snaps-skunkworks/571
Fixes https://github.com/MetaMask/snaps-skunkworks/issues/571

Related to: https://github.com/MetaMask/snaps-skunkworks/issues/209

