### PR TITLE
Upgrade TypeScript to 4.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,8 +52,8 @@
     "prettier-plugin-packagejson": "^2.2.11",
     "rimraf": "^3.0.2",
     "ts-jest": "^26.3.0",
-    "typedoc": "^0.22.15",
-    "typescript": "^4.2.4"
+    "typedoc": "^0.23.10",
+    "typescript": "~4.7.4"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/src/json.test.ts
+++ b/src/json.test.ts
@@ -1,3 +1,4 @@
+import * as superstructModule from 'superstruct';
 import {
   ARRAY_OF_DIFFRENT_KINDS_OF_NUMBERS,
   ARRAY_OF_MIXED_SPECIAL_OBJECTS,
@@ -85,6 +86,16 @@ describe('json', () => {
         'Not a JSON-RPC notification: At path: jsonrpc -- Expected the literal `"2.0"`, but received: undefined.',
       );
     });
+
+    it('includes the value thrown in the message if it is not an error', () => {
+      jest.spyOn(superstructModule, 'assert').mockImplementation(() => {
+        throw 'oops';
+      });
+
+      expect(() =>
+        assertIsJsonRpcNotification(JSON_RPC_NOTIFICATION_FIXTURES.invalid[0]),
+      ).toThrow('Not a JSON-RPC notification: oops');
+    });
   });
 
   describe('isJsonRpcRequest', () => {
@@ -126,6 +137,16 @@ describe('json', () => {
       ).toThrow(
         'Not a JSON-RPC request: At path: id -- Expected the value to satisfy a union of `number | string`, but received: undefined.',
       );
+    });
+
+    it('includes the value thrown in the message if it is not an error', () => {
+      jest.spyOn(superstructModule, 'assert').mockImplementation(() => {
+        throw 'oops';
+      });
+
+      expect(() =>
+        assertIsJsonRpcRequest(JSON_RPC_REQUEST_FIXTURES.invalid[0]),
+      ).toThrow('Not a JSON-RPC request: oops');
     });
   });
 
@@ -169,6 +190,16 @@ describe('json', () => {
         'Not a successful JSON-RPC response: At path: id -- Expected the value to satisfy a union of `number | string`, but received: undefined.',
       );
     });
+
+    it('includes the value thrown in the message if it is not an error', () => {
+      jest.spyOn(superstructModule, 'assert').mockImplementation(() => {
+        throw 'oops';
+      });
+
+      expect(() =>
+        assertIsJsonRpcSuccess(JSON_RPC_SUCCESS_FIXTURES.invalid[0]),
+      ).toThrow('Not a successful JSON-RPC response: oops');
+    });
   });
 
   describe('isJsonRpcFailure', () => {
@@ -211,6 +242,16 @@ describe('json', () => {
         'Not a failed JSON-RPC response: At path: id -- Expected the value to satisfy a union of `number | string`, but received: undefined.',
       );
     });
+
+    it('includes the value thrown in the message if it is not an error', () => {
+      jest.spyOn(superstructModule, 'assert').mockImplementation(() => {
+        throw 'oops';
+      });
+
+      expect(() =>
+        assertIsJsonRpcFailure(JSON_RPC_FAILURE_FIXTURES.invalid[0]),
+      ).toThrow('Not a failed JSON-RPC response: oops');
+    });
   });
 
   describe('isJsonRpcResponse', () => {
@@ -252,6 +293,16 @@ describe('json', () => {
       ).toThrow(
         'Not a JSON-RPC response: Expected the value to satisfy a union of `object | object`, but received: [object Object].',
       );
+    });
+
+    it('includes the value thrown in the message if it is not an error', () => {
+      jest.spyOn(superstructModule, 'assert').mockImplementation(() => {
+        throw 'oops';
+      });
+
+      expect(() =>
+        assertIsJsonRpcResponse(JSON_RPC_RESPONSE_FIXTURES.invalid[0]),
+      ).toThrow('Not a JSON-RPC response: oops');
     });
   });
 

--- a/src/json.ts
+++ b/src/json.ts
@@ -25,6 +25,17 @@ import {
   JsonSize,
 } from './misc';
 
+/**
+ * Type guard for determining whether the given value is an error object with a
+ * `message` property, such as an instance of Error.
+ *
+ * @param error - The object to check.
+ * @returns True or false, depending on the result.
+ */
+function isErrorWithMessage(error: unknown): error is { message: string } {
+  return typeof error === 'object' && error !== null && 'message' in error;
+}
+
 // Note: This struct references itself, so TypeScript cannot infer the type.
 export const JsonStruct: Struct<Json> = union([
   literal(null),
@@ -155,7 +166,8 @@ export function assertIsJsonRpcNotification(
   try {
     assert(requestOrNotification, JsonRpcNotificationStruct);
   } catch (error) {
-    throw new Error(`Not a JSON-RPC notification: ${error.message}.`);
+    const message = isErrorWithMessage(error) ? error.message : error;
+    throw new Error(`Not a JSON-RPC notification: ${message}.`);
   }
 }
 
@@ -183,7 +195,8 @@ export function assertIsJsonRpcRequest(
   try {
     assert(requestOrNotification, JsonRpcRequestStruct);
   } catch (error) {
-    throw new Error(`Not a JSON-RPC request: ${error.message}.`);
+    const message = isErrorWithMessage(error) ? error.message : error;
+    throw new Error(`Not a JSON-RPC request: ${message}.`);
   }
 }
 
@@ -252,7 +265,8 @@ export function assertIsJsonRpcResponse(
   try {
     assert(response, JsonRpcResponseStruct);
   } catch (error) {
-    throw new Error(`Not a JSON-RPC response: ${error.message}.`);
+    const message = isErrorWithMessage(error) ? error.message : error;
+    throw new Error(`Not a JSON-RPC response: ${message}.`);
   }
 }
 
@@ -279,7 +293,8 @@ export function assertIsJsonRpcSuccess(
   try {
     assert(response, JsonRpcSuccessStruct);
   } catch (error) {
-    throw new Error(`Not a successful JSON-RPC response: ${error.message}.`);
+    const message = isErrorWithMessage(error) ? error.message : error;
+    throw new Error(`Not a successful JSON-RPC response: ${message}.`);
   }
 }
 
@@ -307,7 +322,8 @@ export function assertIsJsonRpcFailure(
   try {
     assert(response, JsonRpcFailureStruct);
   } catch (error) {
-    throw new Error(`Not a failed JSON-RPC response: ${error.message}.`);
+    const message = isErrorWithMessage(error) ? error.message : error;
+    throw new Error(`Not a failed JSON-RPC response: ${message}.`);
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2291,18 +2291,6 @@ glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.2.0:
-  version "7.2.3"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
-  integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.1.1"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
 globals@^11.1.0:
   version "11.12.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
@@ -3453,10 +3441,10 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-marked@^4.0.12:
-  version "4.0.15"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-4.0.15.tgz#0216b7c9d5fcf6ac5042343c41d81a8b1b5e1b4a"
-  integrity sha512-esX5lPdTfG4p8LDkv+obbRCyOKzB+820ZZyMOXJZygZBHrH9b3xXR64X4kT3sPe9Nx8qQXbmcz6kFSMt4Nfk6Q==
+marked@^4.0.18:
+  version "4.0.18"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-4.0.18.tgz#cd0ac54b2e5610cfb90e8fd46ccaa8292c9ed569"
+  integrity sha512-wbLDJ7Zh0sqA0Vdg6aqlbT+yPxqLblpAZh1mK2+AO2twQkPywvvqQNfEPVwSSRjZ7dZcdeVBIAgiO7MMp3Dszw==
 
 merge-stream@^2.0.0:
   version "2.0.0"
@@ -3527,17 +3515,10 @@ minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimatch@^3.1.1:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
-  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
-  dependencies:
-    brace-expansion "^1.1.7"
-
-minimatch@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.0.1.tgz#fb9022f7528125187c92bd9e9b6366be1cf3415b"
-  integrity sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==
+minimatch@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.0.tgz#1717b464f4971b144f6aabe8f2d0b8e4511e09c7"
+  integrity sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==
   dependencies:
     brace-expansion "^2.0.1"
 
@@ -4939,21 +4920,20 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typedoc@^0.22.15:
-  version "0.22.15"
-  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.22.15.tgz#c6ad7ed9d017dc2c3a06c9189cb392bd8e2d8c3f"
-  integrity sha512-CMd1lrqQbFvbx6S9G6fL4HKp3GoIuhujJReWqlIvSb2T26vGai+8Os3Mde7Pn832pXYemd9BMuuYWhFpL5st0Q==
+typedoc@^0.23.10:
+  version "0.23.10"
+  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.23.10.tgz#285d595a5f2e35ccdf6f38eba4dfe951d5bff461"
+  integrity sha512-03EUiu/ZuScUBMnY6p0lY+HTH8SwhzvRE3gImoemdPDWXPXlks83UGTx++lyquWeB1MTwm9D9Ca8RIjkK3AFfQ==
   dependencies:
-    glob "^7.2.0"
     lunr "^2.3.9"
-    marked "^4.0.12"
-    minimatch "^5.0.1"
+    marked "^4.0.18"
+    minimatch "^5.1.0"
     shiki "^0.10.1"
 
-typescript@^4.2.4:
-  version "4.2.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.4.tgz#8610b59747de028fda898a8aef0e103f156d0961"
-  integrity sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==
+typescript@~4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 unbox-primitive@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Bump TypeScript and fix compile errors. Specifically, an error that's
caught is now typed as `unknown`, so accessing `message` on that error
object won't work anymore. This is fixed using a type guard.

Also bump `typedoc` to fix peer dependency warnings.