### PR TITLE
Move @types/debug to prod dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "docs:publish": "typedoc --cleanOutputDir false --gitRevision \"v$(jq -r .version < ./package.json)\""
   },
   "dependencies": {
+    "@types/debug": "^4.1.7",
     "debug": "^4.3.4",
     "fast-deep-equal": "^3.1.3",
     "superstruct": "^0.16.0"
@@ -38,7 +39,6 @@
     "@metamask/eslint-config-jest": "^9.0.0",
     "@metamask/eslint-config-nodejs": "^9.0.0",
     "@metamask/eslint-config-typescript": "^9.0.1",
-    "@types/debug": "^4.1.7",
     "@types/jest": "^28.1.7",
     "@typescript-eslint/eslint-plugin": "^4.21.0",
     "@typescript-eslint/parser": "^4.21.0",


### PR DESCRIPTION
In order for another project to use the logging functions provided by
this library, which make use of `debug`, `@types/debug` also needs to be
available. This is not a total blocker — `@types/debug` can be added
manually to the project in question — but is inconvenient. This commit
moves `@types/debug` to the list of `dependencies` to address this.