### PR TITLE
Pin superstruct to 0.16.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@types/debug": "^4.1.7",
     "debug": "^4.3.4",
     "fast-deep-equal": "^3.1.3",
-    "superstruct": "0.16.1"
+    "superstruct": "0.16.0"
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@types/debug": "^4.1.7",
     "debug": "^4.3.4",
     "fast-deep-equal": "^3.1.3",
-    "superstruct": "^0.16.0"
+    "superstruct": "0.16.1"
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^1.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3791,10 +3791,10 @@ strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
-superstruct@0.16.1:
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/superstruct/-/superstruct-0.16.1.tgz#d6d94ae4f9cd4d4845fa122daa070831a435ba28"
-  integrity sha512-TMaihyrSnOQ7m4wI9+zeGERm+BNvvtqWscFHVKUMgDwEb+62bwFzJFfW6US1K6V5G5+42v5gmqRibRX4tYDH9w==
+superstruct@0.16.0:
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/superstruct/-/superstruct-0.16.0.tgz#9af5e059acd08e774789ad8880962427ef68dace"
+  integrity sha512-IDQtwnnlaan1NhuHqyD/U11lROYvCQ79JyfwlFU9xEVHzqV/Ys/RrwmHPCG0CVH/1g0BuodEjH1msxK2UHxehA==
 
 supports-color@^5.3.0:
   version "5.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3791,10 +3791,10 @@ strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
-superstruct@^0.16.0:
-  version "0.16.0"
-  resolved "https://registry.yarnpkg.com/superstruct/-/superstruct-0.16.0.tgz#9af5e059acd08e774789ad8880962427ef68dace"
-  integrity sha512-IDQtwnnlaan1NhuHqyD/U11lROYvCQ79JyfwlFU9xEVHzqV/Ys/RrwmHPCG0CVH/1g0BuodEjH1msxK2UHxehA==
+superstruct@0.16.1:
+  version "0.16.1"
+  resolved "https://registry.yarnpkg.com/superstruct/-/superstruct-0.16.1.tgz#d6d94ae4f9cd4d4845fa122daa070831a435ba28"
+  integrity sha512-TMaihyrSnOQ7m4wI9+zeGERm+BNvvtqWscFHVKUMgDwEb+62bwFzJFfW6US1K6V5G5+42v5gmqRibRX4tYDH9w==
 
 supports-color@^5.3.0:
   version "5.5.0"


### PR DESCRIPTION
The latest published version of `superstruct` makes use of the `??=` operator, which only works on Node >= 16. This operator did not exist in `superstruct` 0.16.0, which is the minimum version that is referred to in `package.json`, but seems to have appeared in 0.16.2. However, the dependence on a version of Node is not represent in `superstruct`'s `package.json`, so to keep this package compatible with Node 14, this commit pins the version to 0.16.1.