### PR TITLE
Bump superstruct to at least 0.16.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@types/debug": "^4.1.7",
     "debug": "^4.3.4",
     "fast-deep-equal": "^3.1.3",
-    "superstruct": "^0.16.0"
+    "superstruct": "^0.16.5"
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^1.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3791,10 +3791,10 @@ strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
-superstruct@^0.16.0:
-  version "0.16.0"
-  resolved "https://registry.yarnpkg.com/superstruct/-/superstruct-0.16.0.tgz#9af5e059acd08e774789ad8880962427ef68dace"
-  integrity sha512-IDQtwnnlaan1NhuHqyD/U11lROYvCQ79JyfwlFU9xEVHzqV/Ys/RrwmHPCG0CVH/1g0BuodEjH1msxK2UHxehA==
+superstruct@^0.16.5:
+  version "0.16.5"
+  resolved "https://registry.yarnpkg.com/superstruct/-/superstruct-0.16.5.tgz#7b7e1f1f8bf6ab141c660e501ac57026e42c09c0"
+  integrity sha512-GBa1VPdCUDAIrsoMVy2lzE/hKQnieUlc1JVoVzJ2YLx47SoPY4AqF85Ht1bPg5r+8I0v54GbaRdNTnYQ0p+T+Q==
 
 supports-color@^5.3.0:
   version "5.5.0"


### PR DESCRIPTION
Published versions of `superstruct` between 0.16.1 and 0.16.4 contained
syntax (`??=`) that Node did not support until v15. This effectively
changed the minimum required Node version for this package, and any
other package using this package, to v15. A [fix for this issue][1]
landed in `superstruct` 0.16.5, so this commit bumps that library
accordingly so as to restore compatibility with Node 14.

[1]: https://github.com/ianstormtaylor/superstruct/pull/1112