### PR TITLE
Allow omitting params when params can be undefined

### DIFF
--- a/src/json.ts
+++ b/src/json.ts
@@ -119,9 +119,14 @@ export const JsonRpcRequestStruct = object({
 export type InferWithParams<
   Type extends Struct<any, unknown>,
   Params extends JsonRpcParams
-> = Omit<Infer<Type>, 'params'> & {
-  params: Params;
-};
+> = Omit<Infer<Type>, 'params'> &
+  (keyof Params extends undefined
+    ? {
+        params?: Params;
+      }
+    : {
+        params: Params;
+      });
 
 /**
  * A JSON-RPC request object.


### PR DESCRIPTION
Before you would always have to specify the params, even if they could be `undefined`. For example, the following would result in an error:

```ts
const request: JsonRpcRequest<string[] | undefined> = {
  jsonrpc: '2.0',
  id: 0,
  method: 'foo',
};
```

Now, when `undefined` is specified as the `Params` generic type, this will work fine. Note that params must still be specified if the `Params` generic doesn't include `undefined`, e.g.:

```ts
// TS2322: Type '{ jsonrpc: "2.0"; id: number; method: string; }' is not
// assignable to type 'JsonRpcRequest<string[]>'.
const request: JsonRpcRequest<string[]> = {
  jsonrpc: '2.0',
  id: 0,
  method: 'foo',
};
```