### PR TITLE
Make JSON-RPC error `data` property optional

### DIFF
--- a/src/json.ts
+++ b/src/json.ts
@@ -101,9 +101,24 @@ export const JsonRpcErrorStruct = object({
 });
 
 /**
- * A JSON-RPC error object.
+ * Mark a certain key of a type as optional.
  */
-export type JsonRpcError = Infer<typeof JsonRpcErrorStruct>;
+export type OptionalField<
+  Type extends Record<string, unknown>,
+  Key extends keyof Type
+> = Omit<Type, Key> & Partial<Pick<Type, Key>>;
+
+/**
+ * A JSON-RPC error object.
+ *
+ * Note that TypeScript infers `unknown | undefined` as `unknown`, meaning that
+ * the `data` field is not optional. To make it optional, we use the
+ * `OptionalField` helper, to explicitly make it optional.
+ */
+export type JsonRpcError = OptionalField<
+  Infer<typeof JsonRpcErrorStruct>,
+  'data'
+>;
 
 export const JsonRpcParamsStruct = optional(union([object(), array()]));
 

--- a/src/json.ts
+++ b/src/json.ts
@@ -239,7 +239,7 @@ export type JsonRpcSuccess<Result extends Json> = Omit<
 export const JsonRpcFailureStruct = object({
   id: JsonRpcIdStruct,
   jsonrpc: JsonRpcVersionStruct,
-  error: JsonRpcErrorStruct,
+  error: JsonRpcErrorStruct as Struct<JsonRpcError>,
 });
 
 /**


### PR DESCRIPTION
This fixes an issue where the `data` property of `JsonRpcError` wasn't properly inferred as optional, but rather as `unknown`. This is due to an issue(?) in TypeScript, where `unknown | undefined` is inferred simply as `unknown`, so Superstruct can't properly make the (type of the) field optional.

It's fixed by adding a new helper type, `OptionalField`, which explicitly makes a property (or multiple properties) of a type optional.

```ts
type JsonRpcError = Infer<typeof JsonRpcErrorStruct>; // { ..., data: unknown }
type JsonRcpError = OptionalField<Infer<typeof JsonRpcErrorStruct>, 'data'>; // { ..., data?: unknown }
```

This does not affect actual runtime validation of the types.