### PR TITLE
Extract build-only TypeScript config

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "dist/"
   ],
   "scripts": {
-    "build": "tsc --project .",
+    "build": "tsc --project tsconfig.build.json",
     "build:clean": "rimraf dist && yarn build",
     "docs": "typedoc",
     "docs:publish": "typedoc --cleanOutputDir false --gitRevision \"v$(jq -r .version < ./package.json)\"",

--- a/src/bytes.ts
+++ b/src/bytes.ts
@@ -81,7 +81,8 @@ export function bytesToHex(bytes: Uint8Array): string {
   const hex = new Array(bytes.length);
 
   for (let i = 0; i < bytes.length; i++) {
-    hex[i] = lookupTable[bytes[i]];
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    hex[i] = lookupTable[bytes[i]!];
   }
 
   return add0x(hex.join(''));
@@ -360,7 +361,8 @@ export function concatBytes(values: Bytes[]): Uint8Array {
   let byteLength = 0;
 
   for (let i = 0; i < values.length; i++) {
-    const value = valueToBytes(values[i]);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const value = valueToBytes(values[i]!);
 
     normalizedValues[i] = value;
     byteLength += value.length;

--- a/src/time.test.ts
+++ b/src/time.test.ts
@@ -58,7 +58,7 @@ describe('time utilities', () => {
         [1, 9],
         [0, 10],
       ].forEach(([input, expected]) => {
-        expect(timeSince(input)).toBe(expected);
+        expect(timeSince(input as number)).toBe(expected);
       });
     });
   });

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "inlineSources": true,
+    "noEmit": false,
+    "outDir": "dist",
+    "rootDir": "src",
+    "sourceMap": true
+  },
+  "include": ["./src/**/*.ts"],
+  "exclude": ["./src/**/*.test.ts", "./src/__fixtures__"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,17 +1,16 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "esModuleInterop": true,
-    "inlineSources": true,
+    "exactOptionalPropertyTypes": true,
+    "forceConsistentCasingInFileNames": true,
     "lib": ["ES2020", "dom"],
     "module": "CommonJS",
-    "moduleResolution": "Node",
-    "outDir": "dist",
-    "rootDir": "src",
-    "sourceMap": true,
+    "moduleResolution": "node",
+    "noEmit": true,
+    "noErrorTruncation": true,
+    "noUncheckedIndexedAccess": true,
     "strict": true,
     "target": "ES2017"
   },
-  "exclude": ["./src/**/*.test.ts"],
-  "include": ["./src/**/*.ts"]
+  "exclude": ["./dist/**/*"]
 }


### PR DESCRIPTION
This implements the latest `tsconfig.json` used in [MetaMask/metamask/module-template](https://github.com/MetaMask/metamask-module-template). It fixes type checking in tests, and makes it possible to exclude the `__fixtures__` folder from the build output.