### PR TITLE
Add coercion utils

### DIFF
--- a/src/__fixtures__/coercions.ts
+++ b/src/__fixtures__/coercions.ts
@@ -1,3 +1,5 @@
+import type { Hex } from '../hex';
+
 export const POSITIVE_INTEGERS = [0, 1, 10, 100, 1000, 123456789, 2147483647];
 export const NEGATIVE_INTEGERS = [
   -1, -10, -100, -1000, -123456789, -2147483647,
@@ -7,7 +9,8 @@ export const DECIMAL_NUMBERS = [
   -1.123456789123456789,
 ];
 
-export const HEX_STRINGS = [
+export const HEX_STRINGS: Hex[] = [
+  '0x',
   '0x00',
   '0x1a',
   '0x2b',

--- a/src/__fixtures__/coercions.ts
+++ b/src/__fixtures__/coercions.ts
@@ -1,0 +1,19 @@
+export const POSITIVE_INTEGERS = [0, 1, 10, 100, 1000, 123456789, 2147483647];
+export const NEGATIVE_INTEGERS = [
+  -1, -10, -100, -1000, -123456789, -2147483647,
+];
+export const DECIMAL_NUMBERS = [
+  1.1, 1.123456789, 1.123456789123456789, -1.1, -1.123456789,
+  -1.123456789123456789,
+];
+
+export const HEX_STRINGS = [
+  '0x00',
+  '0x1a',
+  '0x2b',
+  '0x3c',
+  '0xff',
+  '0xff00ff',
+  '0x1234567890abcdef',
+  '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
+];

--- a/src/__fixtures__/index.ts
+++ b/src/__fixtures__/index.ts
@@ -1,1 +1,3 @@
+export * from './bytes';
+export * from './coercions';
 export * from './json';

--- a/src/bytes.test.ts
+++ b/src/bytes.test.ts
@@ -70,6 +70,10 @@ describe('bytesToHex', () => {
     expect(bytesToHex(new Uint8Array([0, 1, 2])).startsWith('0x')).toBe(true);
   });
 
+  it('returns 0x for an empty byte array', () => {
+    expect(bytesToHex(new Uint8Array())).toBe('0x');
+  });
+
   it.each(INVALID_BYTES_FIXTURES)(
     'throws an error for invalid byte arrays',
     (value) => {
@@ -191,7 +195,11 @@ describe('hexToBytes', () => {
     expect(hexToBytes('abc')).toStrictEqual(new Uint8Array([10, 188]));
   });
 
-  it.each([true, false, null, undefined, 0, 1, '', '0x', [], {}])(
+  it('returns an empty byte array for 0x', () => {
+    expect(hexToBytes('0x')).toStrictEqual(new Uint8Array());
+  });
+
+  it.each([true, false, null, undefined, 0, 1, '', [], {}])(
     'throws an error for invalid hex strings',
     (value) => {
       // @ts-expect-error Invalid type.

--- a/src/bytes.ts
+++ b/src/bytes.ts
@@ -1,5 +1,5 @@
 import { assert } from './assert';
-import { add0x, assertIsHexString, remove0x } from './hex';
+import { add0x, assertIsHexString, Hex, remove0x } from './hex';
 
 // '0'.charCodeAt(0) === 48
 const HEX_MINIMUM_NUMBER_CHARACTER = 48;
@@ -74,8 +74,12 @@ export function assertIsBytes(value: unknown): asserts value is Uint8Array {
  * @param bytes - The bytes to convert to a hexadecimal string.
  * @returns The hexadecimal string.
  */
-export function bytesToHex(bytes: Uint8Array): string {
+export function bytesToHex(bytes: Uint8Array): Hex {
   assertIsBytes(bytes);
+
+  if (bytes.length === 0) {
+    return '0x';
+  }
 
   const lookupTable = getPrecomputedHexValues();
   const hex = new Array(bytes.length);
@@ -166,10 +170,17 @@ export function bytesToString(bytes: Uint8Array): string {
  * Convert a hexadecimal string to a `Uint8Array`. The string can optionally be
  * prefixed with `0x`. It accepts even and odd length strings.
  *
+ * If the value is "0x", an empty `Uint8Array` is returned.
+ *
  * @param value - The hexadecimal string to convert to bytes.
  * @returns The bytes as `Uint8Array`.
  */
 export function hexToBytes(value: string): Uint8Array {
+  // "0x" is often used as empty byte array.
+  if (value?.toLowerCase?.() === '0x') {
+    return new Uint8Array();
+  }
+
   assertIsHexString(value);
 
   // Remove the `0x` prefix if it exists, and pad the string to have an even

--- a/src/bytes.ts
+++ b/src/bytes.ts
@@ -321,6 +321,10 @@ export function stringToBytes(value: string): Uint8Array {
  * Convert a byte-like value to a `Uint8Array`. The value can be a `Uint8Array`,
  * a `bigint`, a `number`, or a `string`.
  *
+ * This will attempt to guess the type of the value based on its type and
+ * contents. For more control over the conversion, use the more specific
+ * conversion functions, such as {@link hexToBytes} or {@link stringToBytes}.
+ *
  * If the value is a `string`, and it is prefixed with `0x`, it will be
  * interpreted as a hexadecimal string. Otherwise, it will be interpreted as a
  * UTF-8 string. To convert a hexadecimal string to bytes without interpreting

--- a/src/bytes.ts
+++ b/src/bytes.ts
@@ -159,7 +159,7 @@ export function bytesToNumber(bytes: Uint8Array): number {
 export function bytesToString(bytes: Uint8Array): string {
   assertIsBytes(bytes);
 
-  return new TextDecoder(undefined).decode(bytes);
+  return new TextDecoder().decode(bytes);
 }
 
 /**

--- a/src/coercers.test.ts
+++ b/src/coercers.test.ts
@@ -1,0 +1,133 @@
+import {
+  DECIMAL_NUMBERS,
+  HEX_STRINGS,
+  NEGATIVE_INTEGERS,
+  POSITIVE_INTEGERS,
+} from './__fixtures__';
+import { createBigInt, createBytes, createHex, createNumber } from './coercers';
+import { add0x } from './hex';
+import { bytesToBigInt, bytesToHex, hexToBytes } from './bytes';
+
+describe('createNumber', () => {
+  it.each(POSITIVE_INTEGERS)(
+    'creates a number from a positive number-like value',
+    (value) => {
+      expect(createNumber(value)).toBe(value);
+      expect(createNumber(BigInt(value))).toBe(value);
+      expect(createNumber(add0x(value.toString(16)))).toBe(value);
+      expect(createNumber(value.toString(10))).toBe(value);
+    },
+  );
+
+  it.each(NEGATIVE_INTEGERS)(
+    'creates a number from a negative number-like value',
+    (value) => {
+      expect(createNumber(value)).toBe(value);
+      expect(createNumber(BigInt(value))).toBe(value);
+      expect(createNumber(value.toString(10))).toBe(value);
+    },
+  );
+
+  it.each(DECIMAL_NUMBERS)(
+    'creates a number from a positive number-like value with decimals',
+    (value) => {
+      expect(createNumber(value)).toBe(value);
+      expect(createNumber(value.toString(10))).toBe(value);
+    },
+  );
+
+  it('throws if the result is not finite', () => {
+    expect(() => createNumber(Infinity)).toThrow(
+      'Expected a number-like value, got "Infinity".',
+    );
+
+    expect(() => createNumber(-Infinity)).toThrow(
+      'Expected a number-like value, got "-Infinity".',
+    );
+  });
+
+  it.each([true, false, null, undefined, NaN, {}, []])(
+    'throws if the value is not a number-like value',
+    (value) => {
+      // @ts-expect-error Invalid type.
+      expect(() => createNumber(value)).toThrow(
+        /Expected a number-like value, got "(.*)"\./u,
+      );
+    },
+  );
+});
+
+describe('createBigInt', () => {
+  it.each(POSITIVE_INTEGERS)(
+    'creates a bigint from a positive number-like value',
+    (value) => {
+      expect(createBigInt(value)).toBe(BigInt(value));
+      expect(createBigInt(add0x(value.toString(16)))).toBe(BigInt(value));
+      expect(createBigInt(value.toString(10))).toBe(BigInt(value));
+    },
+  );
+
+  it.each(NEGATIVE_INTEGERS)(
+    'creates a bigint from a negative number-like value',
+    (value) => {
+      expect(createBigInt(value)).toBe(BigInt(value));
+      expect(createBigInt(value.toString(10))).toBe(BigInt(value));
+    },
+  );
+
+  it.each([true, false, null, undefined, NaN, {}, []])(
+    'throws if the value is not a number-like value',
+    (value) => {
+      // @ts-expect-error Invalid type.
+      expect(() => createBigInt(value)).toThrow(
+        /Expected a number-like value, got "(.*)"\./u,
+      );
+    },
+  );
+});
+
+describe('createHex', () => {
+  it.each(HEX_STRINGS)(
+    'creates a hex string from a byte-like value',
+    (value) => {
+      const bytes = hexToBytes(value);
+
+      expect(createHex(value)).toBe(value);
+      expect(createHex(bytesToBigInt(bytes))).toBe(value);
+      expect(createHex(bytesToHex(bytes))).toBe(value);
+    },
+  );
+
+  it.each([true, false, null, undefined, NaN, {}, []])(
+    'throws if the value is not a bytes-like value',
+    (value) => {
+      // @ts-expect-error Invalid type.
+      expect(() => createHex(value)).toThrow(
+        /Expected a bytes-like value, got "(.*)"\./u,
+      );
+    },
+  );
+});
+
+describe('createBytes', () => {
+  it.each(HEX_STRINGS)(
+    'creates a byte array from a byte-like value',
+    (value) => {
+      const bytes = hexToBytes(value);
+
+      expect(createBytes(value)).toStrictEqual(bytes);
+      expect(createBytes(bytesToBigInt(bytes))).toStrictEqual(bytes);
+      expect(createBytes(bytesToHex(bytes))).toStrictEqual(bytes);
+    },
+  );
+
+  it.each([true, false, null, undefined, NaN, {}, []])(
+    'throws if the value is not a bytes-like value',
+    (value) => {
+      // @ts-expect-error Invalid type.
+      expect(() => createBytes(value)).toThrow(
+        /Expected a bytes-like value, got "(.*)"\./u,
+      );
+    },
+  );
+});

--- a/src/coercers.test.ts
+++ b/src/coercers.test.ts
@@ -6,7 +6,7 @@ import {
 } from './__fixtures__';
 import { createBigInt, createBytes, createHex, createNumber } from './coercers';
 import { add0x } from './hex';
-import { bytesToBigInt, bytesToHex, hexToBytes } from './bytes';
+import { bytesToHex, hexToBytes } from './bytes';
 
 describe('createNumber', () => {
   it.each(POSITIVE_INTEGERS)(
@@ -35,6 +35,11 @@ describe('createNumber', () => {
       expect(createNumber(value.toString(10))).toBe(value);
     },
   );
+
+  it('handles -0', () => {
+    expect(createNumber('-0')).toBe(-0);
+    expect(createNumber(BigInt('-0'))).toBe(0);
+  });
 
   it('throws if the result is not finite', () => {
     expect(() => createNumber(Infinity)).toThrow(
@@ -84,6 +89,11 @@ describe('createBigInt', () => {
       );
     },
   );
+
+  it('handles -0', () => {
+    expect(createBigInt('-0')).toBe(BigInt(0));
+    expect(createBigInt(-0)).toBe(BigInt(0));
+  });
 });
 
 describe('createHex', () => {
@@ -93,12 +103,11 @@ describe('createHex', () => {
       const bytes = hexToBytes(value);
 
       expect(createHex(value)).toBe(value);
-      expect(createHex(bytesToBigInt(bytes))).toBe(value);
       expect(createHex(bytesToHex(bytes))).toBe(value);
     },
   );
 
-  it.each([true, false, null, undefined, NaN, {}, []])(
+  it.each([true, false, null, undefined, NaN, {}, [], '', '11ff'])(
     'throws if the value is not a bytes-like value',
     (value) => {
       // @ts-expect-error Invalid type.
@@ -107,6 +116,11 @@ describe('createHex', () => {
       );
     },
   );
+
+  it('handles empty byte arrays', () => {
+    expect(createHex('0x')).toBe('0x');
+    expect(createHex(new Uint8Array())).toBe('0x');
+  });
 });
 
 describe('createBytes', () => {
@@ -116,12 +130,11 @@ describe('createBytes', () => {
       const bytes = hexToBytes(value);
 
       expect(createBytes(value)).toStrictEqual(bytes);
-      expect(createBytes(bytesToBigInt(bytes))).toStrictEqual(bytes);
       expect(createBytes(bytesToHex(bytes))).toStrictEqual(bytes);
     },
   );
 
-  it.each([true, false, null, undefined, NaN, {}, []])(
+  it.each([true, false, null, undefined, NaN, {}, [], '', '11ff'])(
     'throws if the value is not a bytes-like value',
     (value) => {
       // @ts-expect-error Invalid type.
@@ -130,4 +143,9 @@ describe('createBytes', () => {
       );
     },
   );
+
+  it('handles empty byte arrays', () => {
+    expect(createBytes('0x')).toStrictEqual(new Uint8Array());
+    expect(createBytes(new Uint8Array())).toStrictEqual(new Uint8Array());
+  });
 });

--- a/src/coercers.ts
+++ b/src/coercers.ts
@@ -42,8 +42,9 @@ export type BytesLike = Infer<typeof BytesLikeStruct>;
  *
  * - If the value is a number, it is returned as-is.
  * - If the value is a `bigint`, it is converted to a number.
- * - If the value is a string, it is parsed as a number
- * - If the value is a hex string (starts with "0x"), it is parsed as a number.
+ * - If the value is a string, it is interpreted as a decimal number.
+ * - If the value is a hex string (i.e., it starts with "0x"), it is
+ * interpreted as a hexadecimal number.
  *
  * This validates that the value is a number-like value, and that the resulting
  * number is not `NaN` or `Infinity`.
@@ -86,9 +87,10 @@ export function createNumber(value: NumberLike): number {
  *
  * - If the value is a number, it is converted to a `bigint`.
  * - If the value is a `bigint`, it is returned as-is.
- * - If the value is a string, it is parsed as a `bigint`
- * - If the value is a hex string (starts with "0x"), it is parsed as a
- * `bigint`.
+ * - If the value is a string, it is interpreted as a decimal number and
+ * converted to a `bigint`.
+ * - If the value is a hex string (i.e., it starts with "0x"), it is
+ * interpreted as a hexadecimal number and converted to a `bigint`.
  *
  * @example
  * ```typescript
@@ -121,8 +123,8 @@ export function createBigInt(value: NumberLike): bigint {
  * Create a byte array from a bytes-like value.
  *
  * - If the value is a byte array, it is returned as-is.
- * - If the value is a hex string (starts with "0x"), it is parsed as a byte
- * array.
+ * - If the value is a hex string (i.e., it starts with "0x"), it is interpreted
+ * as a hexadecimal number and converted to a byte array.
  * - If the value is a string, it is interpreted as a UTF-8 string and converted
  * to a byte array.
  * - If the value is a number, it is converted to a byte array.
@@ -156,7 +158,8 @@ export function createBytes(value: BytesLike): Uint8Array {
 /**
  * Create a hexadecimal string from a bytes-like value.
  *
- * - If the value is a hex string, it is returned as-is.
+ * - If the value is a hex string, it is returned as-is (with the "0x" prefix
+ * added if it is missing).
  * - If the value is a string, it is interpreted as a UTF-8 string and converted
  * to a hex string.
  * - If the value is a `Uint8Array`, it is converted to a hex string.

--- a/src/coercers.ts
+++ b/src/coercers.ts
@@ -1,0 +1,193 @@
+import {
+  bigint,
+  coerce,
+  create,
+  Infer,
+  instance,
+  number,
+  string,
+  StructError,
+  union,
+} from 'superstruct';
+import { add0x, HexStruct, isHexString } from './hex';
+import { assert } from './assert';
+import { bytesToHex, valueToBytes } from './bytes';
+
+const NumberLikeStruct = union([number(), bigint(), string()]);
+const NumberCoercer = coerce(number(), NumberLikeStruct, Number);
+const BigIntCoercer = coerce(bigint(), NumberLikeStruct, BigInt);
+
+const BytesLikeStruct = union([
+  string(),
+  instance(Uint8Array),
+  bigint(),
+  number(),
+]);
+
+const BytesCoercer = coerce(
+  instance(Uint8Array),
+  BytesLikeStruct,
+  valueToBytes,
+);
+
+const HexCoercer = coerce(HexStruct, BytesLikeStruct, (value) => {
+  return bytesToHex(valueToBytes(value));
+});
+
+export type NumberLike = Infer<typeof NumberLikeStruct>;
+export type BytesLike = Infer<typeof BytesLikeStruct>;
+
+/**
+ * Create a number from a number-like value.
+ *
+ * - If the value is a number, it is returned as-is.
+ * - If the value is a `bigint`, it is converted to a number.
+ * - If the value is a string, it is parsed as a number
+ * - If the value is a hex string (starts with "0x"), it is parsed as a number.
+ *
+ * This validates that the value is a number-like value, and that the resulting
+ * number is not `NaN` or `Infinity`.
+ *
+ * @example
+ * ```typescript
+ * const value = createNumber('0x010203');
+ * console.log(value); // 66051
+ *
+ * const otherValue = createNumber(123n);
+ * console.log(otherValue); // 123
+ * ```
+ * @param value - The value to create the number from.
+ * @returns The created number.
+ * @throws If the value is not a number-like value, or if the resulting number
+ * is `NaN` or `Infinity`.
+ */
+export function createNumber(value: NumberLike): number {
+  try {
+    const result = create(value, NumberCoercer);
+
+    assert(
+      Number.isFinite(result),
+      `Expected a number-like value, got "${value}".`,
+    );
+
+    return result;
+  } catch (error) {
+    if (error instanceof StructError) {
+      throw new Error(`Expected a number-like value, got "${value}".`);
+    }
+
+    /* istanbul ignore next */
+    throw error;
+  }
+}
+
+/**
+ * Create a `bigint` from a number-like value.
+ *
+ * - If the value is a number, it is converted to a `bigint`.
+ * - If the value is a `bigint`, it is returned as-is.
+ * - If the value is a string, it is parsed as a `bigint`
+ * - If the value is a hex string (starts with "0x"), it is parsed as a
+ * `bigint`.
+ *
+ * @example
+ * ```typescript
+ * const value = createBigInt('0x010203');
+ * console.log(value); // 16909060n
+ *
+ * const otherValue = createBigInt(123);
+ * console.log(otherValue); // 123n
+ * ```
+ * @param value - The value to create the bigint from.
+ * @returns The created bigint.
+ * @throws If the value is not a number-like value.
+ */
+export function createBigInt(value: NumberLike): bigint {
+  try {
+    // The `BigInt` constructor throws if the value is not a number-like value.
+    // There is no need to validate the value manually.
+    return create(value, BigIntCoercer);
+  } catch (error) {
+    if (error instanceof StructError) {
+      throw new Error(`Expected a number-like value, got "${error.value}".`);
+    }
+
+    /* istanbul ignore next */
+    throw error;
+  }
+}
+
+/**
+ * Create a byte array from a bytes-like value.
+ *
+ * - If the value is a byte array, it is returned as-is.
+ * - If the value is a hex string (starts with "0x"), it is parsed as a byte
+ * array.
+ * - If the value is a string, it is interpreted as a UTF-8 string and converted
+ * to a byte array.
+ * - If the value is a number, it is converted to a byte array.
+ * - If the value is a `bigint`, it is converted to a byte array.
+ *
+ * @example
+ * ```typescript
+ * const value = createBytes('0x010203');
+ * console.log(value); // Uint8Array [ 1, 2, 3 ]
+ *
+ * const otherValue = createBytes('Hello, world!');
+ * console.log(otherValue); // Uint8Array [ 72, 101, ... ]
+ * ```
+ * @param value - The value to create the byte array from.
+ * @returns The created byte array.
+ * @throws If the value is not a bytes-like value.
+ */
+export function createBytes(value: BytesLike): Uint8Array {
+  try {
+    return create(value, BytesCoercer);
+  } catch (error) {
+    if (error instanceof StructError) {
+      throw new Error(`Expected a bytes-like value, got "${error.value}".`);
+    }
+
+    /* istanbul ignore next */
+    throw error;
+  }
+}
+
+/**
+ * Create a hexadecimal string from a bytes-like value.
+ *
+ * - If the value is a hex string, it is returned as-is.
+ * - If the value is a string, it is interpreted as a UTF-8 string and converted
+ * to a hex string.
+ * - If the value is a `Uint8Array`, it is converted to a hex string.
+ * - If the value is a number, it is converted to a hex string.
+ * - If the value is a `bigint`, it is converted to a hex string.
+ *
+ * @example
+ * ```typescript
+ * const value = createHex(new Uint8Array([1, 2, 3]));
+ * console.log(value); // '0x010203'
+ *
+ * const otherValue = createHex('Hello, world!');
+ * console.log(otherValue); // '0x48656c6c6f2c20776f726c6421'
+ * ```
+ * @param value - The value to create the hex string from.
+ * @returns The created hex string.
+ * @throws If the value is not a bytes-like value.
+ */
+export function createHex(value: BytesLike): string {
+  if (isHexString(value)) {
+    return add0x(value);
+  }
+
+  try {
+    return create(value, HexCoercer);
+  } catch (error) {
+    if (error instanceof StructError) {
+      throw new Error(`Expected a bytes-like value, got "${error.value}".`);
+    }
+
+    /* istanbul ignore next */
+    throw error;
+  }
+}

--- a/src/hex.test.ts
+++ b/src/hex.test.ts
@@ -1,4 +1,11 @@
-import { add0x, assertIsHexString, isHexString, remove0x } from './hex';
+import {
+  add0x,
+  assertIsHexString,
+  assertIsStrictHexString,
+  isHexString,
+  isStrictHexString,
+  remove0x,
+} from './hex';
 
 describe('isHexString', () => {
   it.each([
@@ -35,6 +42,41 @@ describe('isHexString', () => {
   });
 });
 
+describe('isStrictHexString', () => {
+  it.each([
+    '0x12345',
+    '0x1234567890abcdef',
+    '0x1234567890ABCDEF',
+    '0x1234567890abcdefABCDEF',
+    '0x1234567890abcdefABCDEF1234567890abcdefABCDEF',
+  ])('returns true for a valid hex string', (hexString) => {
+    expect(isStrictHexString(hexString)).toBe(true);
+  });
+
+  it.each([
+    true,
+    false,
+    null,
+    undefined,
+    0,
+    1,
+    {},
+    [],
+    '0x12345g',
+    '0x1234567890abcdefg',
+    '0x1234567890abcdefG',
+    '0x1234567890abcdefABCDEFg',
+    '0x1234567890abcdefABCDEF1234567890abcdefABCDEFg',
+    '12345',
+    '1234567890abcdef',
+    '1234567890ABCDEF',
+    '1234567890abcdefABCDEF',
+    '1234567890abcdefABCDEF1234567890abcdefABCDEF',
+  ])('returns false for an invalid hex string', (hexString) => {
+    expect(isStrictHexString(hexString)).toBe(false);
+  });
+});
+
 describe('assertIsHexString', () => {
   it.each([
     '0x12345',
@@ -68,6 +110,43 @@ describe('assertIsHexString', () => {
   ])('throws for an invalid hex string', (hexString) => {
     expect(() => assertIsHexString(hexString)).toThrow(
       'Value must be a hexadecimal string.',
+    );
+  });
+});
+
+describe('assertIsStrictHexString', () => {
+  it.each([
+    '0x12345',
+    '0x1234567890abcdef',
+    '0x1234567890ABCDEF',
+    '0x1234567890abcdefABCDEF',
+    '0x1234567890abcdefABCDEF1234567890abcdefABCDEF',
+  ])('does not throw for a valid hex string', (hexString) => {
+    expect(() => assertIsStrictHexString(hexString)).not.toThrow();
+  });
+
+  it.each([
+    true,
+    false,
+    null,
+    undefined,
+    0,
+    1,
+    {},
+    [],
+    '0x12345g',
+    '0x1234567890abcdefg',
+    '0x1234567890abcdefG',
+    '0x1234567890abcdefABCDEFg',
+    '0x1234567890abcdefABCDEF1234567890abcdefABCDEFg',
+    '12345',
+    '1234567890abcdef',
+    '1234567890ABCDEF',
+    '1234567890abcdefABCDEF',
+    '1234567890abcdefABCDEF1234567890abcdefABCDEF',
+  ])('throws for an invalid hex string', (hexString) => {
+    expect(() => assertIsStrictHexString(hexString)).toThrow(
+      'Value must be a hexadecimal string, starting with "0x".',
     );
   });
 });

--- a/src/hex.test.ts
+++ b/src/hex.test.ts
@@ -79,7 +79,7 @@ describe('add0x', () => {
 
   it('does not add a 0x-prefix if it is already present', () => {
     expect(add0x('0x12345')).toBe('0x12345');
-    expect(add0x('0X12345')).toBe('0X12345');
+    expect(add0x('0X12345')).toBe('0x12345');
   });
 });
 

--- a/src/hex.ts
+++ b/src/hex.ts
@@ -1,7 +1,7 @@
 import { is, pattern, string } from 'superstruct';
 import { assert } from './assert';
 
-const HexStruct = pattern(string(), /^(?:0x)?[0-9a-f]+$/iu);
+export const HexStruct = pattern(string(), /^(?:0x)?[0-9a-f]+$/iu);
 
 /**
  * Check if a string is a valid hex string.
@@ -31,8 +31,12 @@ export function assertIsHexString(value: unknown): asserts value is string {
  * @returns The prefixed hexadecimal string.
  */
 export function add0x(hex: string): string {
-  if (hex.startsWith('0x') || hex.startsWith('0X')) {
+  if (hex.startsWith('0x')) {
     return hex;
+  }
+
+  if (hex.startsWith('0X')) {
+    return `0x${hex.substring(2)}`;
   }
 
   return `0x${hex}`;

--- a/src/hex.ts
+++ b/src/hex.ts
@@ -1,7 +1,13 @@
-import { is, pattern, string } from 'superstruct';
+import { is, pattern, string, Struct } from 'superstruct';
 import { assert } from './assert';
 
+export type Hex = `0x${string}`;
+
 export const HexStruct = pattern(string(), /^(?:0x)?[0-9a-f]+$/iu);
+export const StrictHexStruct = pattern(string(), /^0x[0-9a-f]+$/iu) as Struct<
+  Hex,
+  null
+>;
 
 /**
  * Check if a string is a valid hex string.
@@ -11,6 +17,17 @@ export const HexStruct = pattern(string(), /^(?:0x)?[0-9a-f]+$/iu);
  */
 export function isHexString(value: unknown): value is string {
   return is(value, HexStruct);
+}
+
+/**
+ * Strictly check if a string is a valid hex string. A valid hex string must
+ * start with the "0x"-prefix.
+ *
+ * @param value - The value to check.
+ * @returns Whether the value is a valid hex string.
+ */
+export function isStrictHexString(value: unknown): value is Hex {
+  return is(value, StrictHexStruct);
 }
 
 /**
@@ -24,15 +41,29 @@ export function assertIsHexString(value: unknown): asserts value is string {
 }
 
 /**
+ * Assert that a value is a valid hex string. A valid hex string must start with
+ * the "0x"-prefix.
+ *
+ * @param value - The value to check.
+ * @throws If the value is not a valid hex string.
+ */
+export function assertIsStrictHexString(value: unknown): asserts value is Hex {
+  assert(
+    isStrictHexString(value),
+    'Value must be a hexadecimal string, starting with "0x".',
+  );
+}
+
+/**
  * Add the `0x`-prefix to a hexadecimal string. If the string already has the
  * prefix, it is returned as-is.
  *
  * @param hex - The hexadecimal string to add the prefix to.
  * @returns The prefixed hexadecimal string.
  */
-export function add0x(hex: string): string {
+export function add0x(hex: string): Hex {
   if (hex.startsWith('0x')) {
-    return hex;
+    return hex as Hex;
   }
 
   if (hex.startsWith('0X')) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export * from './assert';
 export * from './bytes';
+export * from './coercers';
 export * from './collections';
 export * from './hex';
 export * from './json';


### PR DESCRIPTION
This adds utils for coercing values to a standardised value, e.g., a number or string to `bigint`, or a hexadecimal string to a byte array, with some simple utility functions.