### PR TITLE
Add convenience function for creating a `DataView`

### DIFF
--- a/src/bytes.test.ts
+++ b/src/bytes.test.ts
@@ -7,6 +7,7 @@ import {
   bytesToSignedBigInt,
   bytesToString,
   concatBytes,
+  createDataView,
   hexToBytes,
   isBytes,
   numberToBytes,
@@ -412,5 +413,59 @@ describe('concatBytes', () => {
     expect(
       concatBytes([new Uint8Array([1]), 2, BigInt(3), '4', '0x5']),
     ).toStrictEqual(Uint8Array.from([1, 2, 3, 52, 5]));
+  });
+});
+
+describe('createDataView', () => {
+  it('returns a DataView from a byte array', () => {
+    const dataView = createDataView(new Uint8Array([1, 2, 3]));
+
+    expect(dataView).toBeInstanceOf(DataView);
+    expect(dataView.getUint8(0)).toBe(1);
+    expect(dataView.getUint8(1)).toBe(2);
+    expect(dataView.getUint8(2)).toBe(3);
+  });
+
+  it('returns a DataView from a subarray of a byte array', () => {
+    const original = new Uint8Array([1, 2, 3, 4, 5]);
+    const subset = original.subarray(1, 4);
+
+    const dataView = createDataView(subset);
+
+    expect(dataView).toBeInstanceOf(DataView);
+    expect(dataView.byteOffset).toBe(1);
+    expect(dataView.byteLength).toBe(3);
+    expect(dataView.getUint8(0)).toBe(2);
+    expect(dataView.getUint8(1)).toBe(3);
+    expect(dataView.getUint8(2)).toBe(4);
+  });
+
+  it('returns a DataView from a slice of a byte array', () => {
+    const original = new Uint8Array([1, 2, 3, 4, 5]);
+    const subset = original.slice(1, 4);
+
+    const dataView = createDataView(subset);
+
+    expect(dataView).toBeInstanceOf(DataView);
+    expect(dataView.byteOffset).toBe(0);
+    expect(dataView.byteLength).toBe(3);
+    expect(dataView.getUint8(0)).toBe(2);
+    expect(dataView.getUint8(1)).toBe(3);
+    expect(dataView.getUint8(2)).toBe(4);
+  });
+
+  it('allows overriding the byte offset and length', () => {
+    const original = new Uint8Array([1, 2, 3, 4, 5]);
+    const subset = original.slice(1, 4);
+
+    const dataView = createDataView(subset, 1, 1);
+
+    expect(dataView).toBeInstanceOf(DataView);
+    expect(dataView.byteOffset).toBe(1);
+    expect(dataView.byteLength).toBe(1);
+    expect(dataView.getUint8(0)).toBe(3);
+    expect(() => dataView.getUint8(1)).toThrow(
+      'Offset is outside the bounds of the DataView',
+    );
   });
 });

--- a/src/bytes.test.ts
+++ b/src/bytes.test.ts
@@ -417,55 +417,81 @@ describe('concatBytes', () => {
 });
 
 describe('createDataView', () => {
-  it('returns a DataView from a byte array', () => {
-    const dataView = createDataView(new Uint8Array([1, 2, 3]));
+  describe('Uint8Array', () => {
+    it('returns a DataView from a byte array', () => {
+      const dataView = createDataView(new Uint8Array([1, 2, 3]));
 
-    expect(dataView).toBeInstanceOf(DataView);
-    expect(dataView.getUint8(0)).toBe(1);
-    expect(dataView.getUint8(1)).toBe(2);
-    expect(dataView.getUint8(2)).toBe(3);
+      expect(dataView).toBeInstanceOf(DataView);
+      expect(dataView.getUint8(0)).toBe(1);
+      expect(dataView.getUint8(1)).toBe(2);
+      expect(dataView.getUint8(2)).toBe(3);
+    });
+
+    it('returns a DataView from a subarray of a byte array', () => {
+      const original = new Uint8Array([1, 2, 3, 4, 5]);
+      const subset = original.subarray(1, 4);
+
+      const dataView = createDataView(subset);
+
+      expect(dataView).toBeInstanceOf(DataView);
+      expect(dataView.byteOffset).toBe(1);
+      expect(dataView.byteLength).toBe(3);
+      expect(dataView.getUint8(0)).toBe(2);
+      expect(dataView.getUint8(1)).toBe(3);
+      expect(dataView.getUint8(2)).toBe(4);
+    });
+
+    it('returns a DataView from a slice of a byte array', () => {
+      const original = new Uint8Array([1, 2, 3, 4, 5]);
+      const subset = original.slice(1, 4);
+
+      const dataView = createDataView(subset);
+
+      expect(dataView).toBeInstanceOf(DataView);
+      expect(dataView.byteOffset).toBe(0);
+      expect(dataView.byteLength).toBe(3);
+      expect(dataView.getUint8(0)).toBe(2);
+      expect(dataView.getUint8(1)).toBe(3);
+      expect(dataView.getUint8(2)).toBe(4);
+    });
   });
 
-  it('returns a DataView from a subarray of a byte array', () => {
-    const original = new Uint8Array([1, 2, 3, 4, 5]);
-    const subset = original.subarray(1, 4);
+  describe('Node.js Buffer', () => {
+    it('returns a DataView from a byte array', () => {
+      const dataView = createDataView(Buffer.from([1, 2, 3]));
 
-    const dataView = createDataView(subset);
+      expect(dataView).toBeInstanceOf(DataView);
+      expect(dataView.getUint8(0)).toBe(1);
+      expect(dataView.getUint8(1)).toBe(2);
+      expect(dataView.getUint8(2)).toBe(3);
+    });
 
-    expect(dataView).toBeInstanceOf(DataView);
-    expect(dataView.byteOffset).toBe(1);
-    expect(dataView.byteLength).toBe(3);
-    expect(dataView.getUint8(0)).toBe(2);
-    expect(dataView.getUint8(1)).toBe(3);
-    expect(dataView.getUint8(2)).toBe(4);
-  });
+    it('returns a DataView from a subarray of a byte array', () => {
+      const original = Buffer.from([1, 2, 3, 4, 5]);
+      const subset = original.subarray(1, 4);
 
-  it('returns a DataView from a slice of a byte array', () => {
-    const original = new Uint8Array([1, 2, 3, 4, 5]);
-    const subset = original.slice(1, 4);
+      const dataView = createDataView(subset);
 
-    const dataView = createDataView(subset);
+      expect(dataView).toBeInstanceOf(DataView);
+      expect(dataView.byteOffset).toBe(0);
+      expect(dataView.byteLength).toBe(3);
+      expect(dataView.getUint8(0)).toBe(2);
+      expect(dataView.getUint8(1)).toBe(3);
+      expect(dataView.getUint8(2)).toBe(4);
+    });
 
-    expect(dataView).toBeInstanceOf(DataView);
-    expect(dataView.byteOffset).toBe(0);
-    expect(dataView.byteLength).toBe(3);
-    expect(dataView.getUint8(0)).toBe(2);
-    expect(dataView.getUint8(1)).toBe(3);
-    expect(dataView.getUint8(2)).toBe(4);
-  });
+    it('returns a DataView from a slice of a byte array', () => {
+      const original = Buffer.from([1, 2, 3, 4, 5]);
+      const subset = original.slice(1, 4);
 
-  it('allows overriding the byte offset and length', () => {
-    const original = new Uint8Array([1, 2, 3, 4, 5]);
-    const subset = original.slice(1, 4);
+      const dataView = createDataView(subset);
 
-    const dataView = createDataView(subset, 1, 1);
-
-    expect(dataView).toBeInstanceOf(DataView);
-    expect(dataView.byteOffset).toBe(1);
-    expect(dataView.byteLength).toBe(1);
-    expect(dataView.getUint8(0)).toBe(3);
-    expect(() => dataView.getUint8(1)).toThrow(
-      'Offset is outside the bounds of the DataView',
-    );
+      expect(dataView).toBeInstanceOf(DataView);
+      expect(dataView.byteOffset).toBe(0);
+      expect(dataView.byteLength).toBe(3);
+      expect(dataView.getUint8(0)).toBe(2);
+      expect(dataView.getUint8(1)).toBe(3);
+      expect(dataView.getUint8(2)).toBe(4);
+    });
   });
 });

--- a/src/bytes.ts
+++ b/src/bytes.ts
@@ -403,6 +403,8 @@ export function concatBytes(values: Bytes[]): Uint8Array {
  * unexpected behavior when the {@link Uint8Array} is a view of a larger
  * {@link ArrayBuffer}, e.g., when using {@link Uint8Array.subarray}.
  *
+ * This function also supports Node.js {@link Buffer}s.
+ *
  * @example
  * ```typescript
  * const bytes = new Uint8Array([1, 2, 3]);
@@ -412,16 +414,17 @@ export function concatBytes(values: Bytes[]): Uint8Array {
  * const dataView = createDataView(bytes);
  * ```
  * @param bytes - The bytes to create the {@link DataView} from.
- * @param byteOffset - The offset of the first byte to read. Defaults to
- * `bytes.byteOffset`.
- * @param byteLength - The length of the bytes to read. Defaults to
- * `bytes.byteLength`.
  * @returns The {@link DataView}.
  */
-export function createDataView(
-  bytes: Uint8Array,
-  byteOffset = bytes.byteOffset,
-  byteLength = bytes.byteLength,
-): DataView {
-  return new DataView(bytes.buffer, byteOffset, byteLength);
+export function createDataView(bytes: Uint8Array): DataView {
+  if (typeof Buffer !== 'undefined' && bytes instanceof Buffer) {
+    const buffer = bytes.buffer.slice(
+      bytes.byteOffset,
+      bytes.byteOffset + bytes.byteLength,
+    );
+
+    return new DataView(buffer);
+  }
+
+  return new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
 }

--- a/src/bytes.ts
+++ b/src/bytes.ts
@@ -393,3 +393,35 @@ export function concatBytes(values: Bytes[]): Uint8Array {
 
   return bytes;
 }
+
+/**
+ * Create a {@link DataView} from a {@link Uint8Array}. This is a convenience
+ * function that avoids having to create a {@link DataView} manually, which
+ * requires passing the `byteOffset` and `byteLength` parameters every time.
+ *
+ * Not passing the `byteOffset` and `byteLength` parameters can result in
+ * unexpected behavior when the {@link Uint8Array} is a view of a larger
+ * {@link ArrayBuffer}, e.g., when using {@link Uint8Array.subarray}.
+ *
+ * @example
+ * ```typescript
+ * const bytes = new Uint8Array([1, 2, 3]);
+ *
+ * // This is equivalent to:
+ * // const dataView = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+ * const dataView = createDataView(bytes);
+ * ```
+ * @param bytes - The bytes to create the {@link DataView} from.
+ * @param byteOffset - The offset of the first byte to read. Defaults to
+ * `bytes.byteOffset`.
+ * @param byteLength - The length of the bytes to read. Defaults to
+ * `bytes.byteLength`.
+ * @returns The {@link DataView}.
+ */
+export function createDataView(
+  bytes: Uint8Array,
+  byteOffset = bytes.byteOffset,
+  byteLength = bytes.byteLength,
+): DataView {
+  return new DataView(bytes.buffer, byteOffset, byteLength);
+}


### PR DESCRIPTION
`DataView` is great for reading bytes of certain lengths from a byte array. One quirk of it is that if you're working with subarrays of `Uint8Arrays`, the original `ArrayBuffer` still refers to the full `Uint8Array`, so the `DataView` will operate on the entire byte array. To solve this I added a small convenience function, which always takes the `byteOffset` and `byteLength` of the `Uint8Array` into account.