### PR TITLE
Cast JsonRPC to Json

### DIFF
--- a/src/json.test.ts
+++ b/src/json.test.ts
@@ -40,7 +40,7 @@ describe('json', () => {
     it('returns error message', () => {
       const [error] = validate(undefined, JsonStruct);
       assert(error !== undefined);
-      expect(error.message).toStrictEqual('Expected valid JSON value');
+      expect(error.message).toStrictEqual('Expected a valid JSON-serializable value');
     });
   });
 

--- a/src/json.test.ts
+++ b/src/json.test.ts
@@ -1,4 +1,5 @@
 import * as superstructModule from 'superstruct';
+import { validate } from 'superstruct';
 import {
   ARRAY_OF_DIFFRENT_KINDS_OF_NUMBERS,
   COMPLEX_OBJECT,
@@ -13,6 +14,8 @@ import {
   NON_SERIALIZABLE_NESTED_OBJECT,
 } from './__fixtures__';
 import {
+  assert,
+  assertIsJsonRpcError,
   assertIsJsonRpcFailure,
   assertIsJsonRpcNotification,
   assertIsJsonRpcRequest,
@@ -20,6 +23,7 @@ import {
   assertIsJsonRpcSuccess,
   assertIsPendingJsonRpcResponse,
   getJsonRpcIdValidator,
+  isJsonRpcError,
   isJsonRpcFailure,
   isJsonRpcNotification,
   isJsonRpcRequest,
@@ -27,12 +31,19 @@ import {
   isJsonRpcSuccess,
   isPendingJsonRpcResponse,
   isValidJson,
+  JsonStruct,
   validateJsonAndGetSize,
-  isJsonRpcError,
-  assertIsJsonRpcError,
 } from '.';
 
 describe('json', () => {
+  describe('JsonStruct', () => {
+    it('returns error message', () => {
+      const [error] = validate(undefined, JsonStruct);
+      assert(error !== undefined);
+      expect(error.message).toStrictEqual('Expected valid JSON value');
+    });
+  });
+
   // TODO: Make this test suite exhaustive.
   // The current implementation is guaranteed to be correct, but in the future
   // we may opt for a bespoke implementation that is more performant, but may
@@ -425,11 +436,11 @@ describe('json', () => {
     };
 
     const validateAll = (
-      validate: ReturnType<typeof getJsonRpcIdValidator>,
+      validator: ReturnType<typeof getJsonRpcIdValidator>,
       inputs: ReturnType<typeof getInputs>,
     ) => {
       for (const input of Object.values(inputs)) {
-        expect(validate(input.value)).toStrictEqual(input.expected);
+        expect(validator(input.value)).toStrictEqual(input.expected);
       }
     };
 

--- a/src/json.test.ts
+++ b/src/json.test.ts
@@ -40,7 +40,9 @@ describe('json', () => {
     it('returns error message', () => {
       const [error] = validate(undefined, JsonStruct);
       assert(error !== undefined);
-      expect(error.message).toStrictEqual('Expected a valid JSON-serializable value');
+      expect(error.message).toStrictEqual(
+        'Expected a valid JSON-serializable value',
+      );
     });
   });
 

--- a/src/json.ts
+++ b/src/json.ts
@@ -10,6 +10,7 @@ import {
   object,
   omit,
   optional,
+  record,
   string,
   Struct,
   union,
@@ -25,7 +26,10 @@ import {
 
 export const JsonStruct = define<Json>('Json', (value) => {
   const [isValid] = validateJsonAndGetSize(value, true);
-  return isValid;
+  if (!isValid) {
+    return 'Expected valid JSON value';
+  }
+  return true;
 });
 
 /**
@@ -99,11 +103,9 @@ export type JsonRpcError = OptionalField<
   'data'
 >;
 
-export const JsonRpcParamsStruct = optional<
-  Record<string, Json> | Json[],
-  null
->(union([object(), array()]) as Struct<Record<string, Json> | Json[], null>);
-
+export const JsonRpcParamsStruct = optional(
+  union([record(string(), JsonStruct), array(JsonStruct)]),
+);
 export type JsonRpcParams = Infer<typeof JsonRpcParamsStruct>;
 
 export const JsonRpcRequestStruct = object({

--- a/src/json.ts
+++ b/src/json.ts
@@ -27,7 +27,7 @@ import {
 export const JsonStruct = define<Json>('Json', (value) => {
   const [isValid] = validateJsonAndGetSize(value, true);
   if (!isValid) {
-    return 'Expected valid JSON value';
+    return 'Expected a valid JSON-serializable value';
   }
   return true;
 });

--- a/src/json.ts
+++ b/src/json.ts
@@ -15,13 +15,13 @@ import {
   union,
   unknown,
 } from 'superstruct';
+import { AssertionErrorConstructor, assertStruct } from './assert';
 import {
   calculateNumberSize,
   calculateStringSize,
   isPlainObject,
   JsonSize,
 } from './misc';
-import { AssertionErrorConstructor, assertStruct } from './assert';
 
 export const JsonStruct = define<Json>('Json', (value) => {
   const [isValid] = validateJsonAndGetSize(value, true);
@@ -99,7 +99,10 @@ export type JsonRpcError = OptionalField<
   'data'
 >;
 
-export const JsonRpcParamsStruct = optional(union([object(), array()]));
+export const JsonRpcParamsStruct = optional<
+  Record<string, Json> | Json[],
+  null
+>(union([object(), array()]) as Struct<Record<string, Json> | Json[], null>);
 
 export type JsonRpcParams = Infer<typeof JsonRpcParamsStruct>;
 


### PR DESCRIPTION
JsonRpcStruct params was type Record<string, unknown> | unknown[], but in other parts of the code we use Json to denote such structures. unknown is not castable to Json because of undefined and classes. This commit solves the compatibillity issue with other parts of the code