### PR TITLE
Improve the `hasProperty` function

### DIFF
--- a/src/misc.test-d.ts
+++ b/src/misc.test-d.ts
@@ -1,6 +1,6 @@
 import { expectAssignable, expectNotAssignable } from 'tsd';
 
-import { isObject, hasProperty, RuntimeObject } from '.';
+import { isObject, hasProperty, RuntimeObject, ValidPropertyType } from '.';
 
 //=============================================================================
 // isObject
@@ -36,6 +36,20 @@ if (isObject(unknownObject)) {
   expectNotAssignable<Record<'foo', unknown>>(unknownObject);
 }
 
+// An object is accepted after `hasProperty` is used to prove that it has the required property.
+if (isObject(unknownObject) && hasProperty(unknownObject, 'foo')) {
+  expectAssignable<Record<'foo', unknown>>(unknownObject);
+}
+
+// An object is accepted after `hasProperty` is used to prove that it has all required properties.
+if (
+  isObject(unknownObject) &&
+  hasProperty(unknownObject, 'foo') &&
+  hasProperty(unknownObject, 'bar')
+) {
+  expectAssignable<Record<'foo' | 'bar', unknown>>(unknownObject);
+}
+
 // An object is not accepted after `hasProperty` has only been used to establish that some required properties exist.
 if (isObject(unknownObject) && hasProperty(unknownObject, 'foo')) {
   expectNotAssignable<Record<'foo' | 'bar', unknown>>(unknownObject);
@@ -46,6 +60,32 @@ const overlappingTypesExample = { foo: 'foo', baz: 'baz' };
 if (hasProperty(overlappingTypesExample, 'foo')) {
   expectAssignable<Record<'baz', unknown>>(overlappingTypesExample);
 }
+
+//=============================================================================
+// ValidPropertyType
+//=============================================================================
+
+// Valid properties:
+
+expectAssignable<ValidPropertyType>('a');
+
+expectAssignable<ValidPropertyType>(1);
+
+expectAssignable<ValidPropertyType>(Symbol('a'));
+
+// Invalid properties:
+
+expectNotAssignable<ValidPropertyType>(null);
+
+expectNotAssignable<ValidPropertyType>(undefined);
+
+expectNotAssignable<ValidPropertyType>({});
+
+expectNotAssignable<ValidPropertyType>([]);
+
+expectNotAssignable<ValidPropertyType>(() => {
+  // no-op
+});
 
 //=============================================================================
 // RuntimeObject

--- a/src/misc.test-d.ts
+++ b/src/misc.test-d.ts
@@ -1,6 +1,6 @@
 import { expectAssignable, expectNotAssignable } from 'tsd';
 
-import { isObject, hasProperty, RuntimeObject, ValidPropertyType } from '.';
+import { isObject, hasProperty, RuntimeObject } from './misc';
 
 //=============================================================================
 // isObject
@@ -60,32 +60,6 @@ const overlappingTypesExample = { foo: 'foo', baz: 'baz' };
 if (hasProperty(overlappingTypesExample, 'foo')) {
   expectAssignable<Record<'baz', unknown>>(overlappingTypesExample);
 }
-
-//=============================================================================
-// ValidPropertyType
-//=============================================================================
-
-// Valid properties:
-
-expectAssignable<ValidPropertyType>('a');
-
-expectAssignable<ValidPropertyType>(1);
-
-expectAssignable<ValidPropertyType>(Symbol('a'));
-
-// Invalid properties:
-
-expectNotAssignable<ValidPropertyType>(null);
-
-expectNotAssignable<ValidPropertyType>(undefined);
-
-expectNotAssignable<ValidPropertyType>({});
-
-expectNotAssignable<ValidPropertyType>([]);
-
-expectNotAssignable<ValidPropertyType>(() => {
-  // no-op
-});
 
 //=============================================================================
 // RuntimeObject

--- a/src/misc.test.ts
+++ b/src/misc.test.ts
@@ -109,10 +109,7 @@ describe('miscellaneous', () => {
         [
           [{}, 'a'],
           [{ a: 1 }, 'b'],
-          // Object.hasOwnProperty does not work for arrays
-          // [['foo'], 0],
-          // [['foo'], '0'],
-        ] as any[]
+        ] as const
       ).forEach(([objectValue, property]) => {
         expect(hasProperty(objectValue, property)).toBe(false);
       });

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -32,10 +32,14 @@ export type PartialOrAbsent<Value> = Partial<Value> | null | undefined;
 export type NonEmptyArray<Element> = [Element, ...Element[]];
 
 /**
- * A JavaScript object that is not `null`, a function, or an array. The object
- * can still be an instance of a class.
+ * Any type that can be used as the name of an object property.
  */
-export type RuntimeObject = Record<number | string | symbol, unknown>;
+export type ValidPropertyType = string | number | symbol;
+
+/**
+ * A JavaScript object that is not `null`, a function, or an array.
+ */
+export type RuntimeObject = Record<ValidPropertyType, unknown>;
 
 //
 // Type Guards
@@ -80,17 +84,21 @@ export function isObject(value: unknown): value is RuntimeObject {
 //
 
 /**
- * An alias for {@link Object.hasOwnProperty}.
+ * A type guard for ensuring an object has a property.
  *
- * @param object - The object to check.
+ * @param objectToCheck - The object to check.
  * @param name - The property name to check for.
  * @returns Whether the specified object has an own property with the specified
  * name, regardless of whether it is enumerable or not.
  */
-export const hasProperty = (
-  object: RuntimeObject,
-  name: string | number | symbol,
-): boolean => Object.hasOwnProperty.call(object, name);
+export const hasProperty = <
+  ObjectToCheck extends RuntimeObject,
+  Property extends ValidPropertyType,
+>(
+  objectToCheck: ObjectToCheck,
+  name: Property,
+): objectToCheck is ObjectToCheck & Record<Property, unknown> =>
+  Object.hasOwnProperty.call(objectToCheck, name);
 
 export type PlainObject = Record<number | string | symbol, unknown>;
 

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -32,14 +32,9 @@ export type PartialOrAbsent<Value> = Partial<Value> | null | undefined;
 export type NonEmptyArray<Element> = [Element, ...Element[]];
 
 /**
- * Any type that can be used as the name of an object property.
- */
-export type ValidPropertyType = string | number | symbol;
-
-/**
  * A JavaScript object that is not `null`, a function, or an array.
  */
-export type RuntimeObject = Record<ValidPropertyType, unknown>;
+export type RuntimeObject = Record<PropertyKey, unknown>;
 
 //
 // Type Guards
@@ -93,7 +88,7 @@ export function isObject(value: unknown): value is RuntimeObject {
  */
 export const hasProperty = <
   ObjectToCheck extends RuntimeObject,
-  Property extends ValidPropertyType,
+  Property extends PropertyKey,
 >(
   objectToCheck: ObjectToCheck,
   name: Property,


### PR DESCRIPTION
The `hasProperty` function now tells TypeScript that the property exists, making it more effective as a type guard.

A `ValidPropertyTypes` type has been added as well, for convenience.