### PR TITLE
Improve compatibility of `hasProperty`

### DIFF
--- a/src/misc.test-d.ts
+++ b/src/misc.test-d.ts
@@ -1,4 +1,9 @@
-import { expectAssignable, expectNotAssignable } from 'tsd';
+import {
+  expectAssignable,
+  expectError,
+  expectNotAssignable,
+  expectType,
+} from 'tsd';
 
 import { isObject, hasProperty, RuntimeObject } from './misc';
 
@@ -61,6 +66,34 @@ if (hasProperty(overlappingTypesExample, 'foo')) {
   expectAssignable<Record<'baz', unknown>>(overlappingTypesExample);
 }
 
+const exampleErrorWithCode = new Error('test');
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+exampleErrorWithCode.code = 999;
+
+// Establish that trying to check for a custom property on an error results in faulre
+expectError(exampleErrorWithCode.code);
+
+// Using custom Error property is allowed after checking with `hasProperty`
+if (hasProperty(exampleErrorWithCode, 'code')) {
+  expectType<unknown>(exampleErrorWithCode.code);
+}
+
+// `hasProperty` is compatible with interfaces
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+interface HasPropertyInterfaceExample {
+  a: number;
+}
+const hasPropertyInterfaceExample: HasPropertyInterfaceExample = { a: 0 };
+hasProperty(hasPropertyInterfaceExample, 'a');
+
+// `hasProperty` is compatible with classes
+class HasPropertyClassExample {
+  a!: number;
+}
+const hasPropertyClassExample = new HasPropertyClassExample();
+hasProperty(hasPropertyClassExample, 'a');
+
 //=============================================================================
 // RuntimeObject
 //=============================================================================
@@ -101,14 +134,14 @@ expectNotAssignable<RuntimeObject>(Symbol('test'));
 // The RuntimeObject type gets confused by interfaces. This interface is a valid object,
 // but it's incompatible with the RuntimeObject type.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-interface A {
+interface RuntimeObjectInterfaceExample {
   a: number;
 }
-const a: A = { a: 0 };
-expectNotAssignable<RuntimeObject>(a);
+const runtimeObjectInterfaceExample: RuntimeObjectInterfaceExample = { a: 0 };
+expectNotAssignable<RuntimeObject>(runtimeObjectInterfaceExample);
 
-class Foo {
+class RuntimeObjectClassExample {
   a!: number;
 }
-const foo = new Foo();
-expectNotAssignable<RuntimeObject>(foo);
+const runtimeObjectClassExample = new RuntimeObjectClassExample();
+expectNotAssignable<RuntimeObject>(runtimeObjectClassExample);

--- a/src/misc.test-d.ts
+++ b/src/misc.test-d.ts
@@ -1,9 +1,4 @@
-import {
-  expectAssignable,
-  expectError,
-  expectNotAssignable,
-  expectType,
-} from 'tsd';
+import { expectAssignable, expectNotAssignable, expectType } from 'tsd';
 
 import { isObject, hasProperty, RuntimeObject } from './misc';
 
@@ -71,8 +66,8 @@ const exampleErrorWithCode = new Error('test');
 // @ts-ignore
 exampleErrorWithCode.code = 999;
 
-// Establish that trying to check for a custom property on an error results in faulre
-expectError(exampleErrorWithCode.code);
+// Establish that trying to check for a custom property on an error results in failure
+expectNotAssignable<{ code: any }>(exampleErrorWithCode);
 
 // Using custom Error property is allowed after checking with `hasProperty`
 if (hasProperty(exampleErrorWithCode, 'code')) {

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -87,7 +87,8 @@ export function isObject(value: unknown): value is RuntimeObject {
  * name, regardless of whether it is enumerable or not.
  */
 export const hasProperty = <
-  ObjectToCheck extends RuntimeObject,
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  ObjectToCheck extends Object,
   Property extends PropertyKey,
 >(
   objectToCheck: ObjectToCheck,

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -9,5 +9,9 @@
     "sourceMap": true
   },
   "include": ["./src/**/*.ts"],
-  "exclude": ["./src/**/*.test.ts", "./src/__fixtures__"]
+  "exclude": [
+    "./src/**/*.test.ts",
+    "./src/**/*.test-d.ts",
+    "./src/__fixtures__"
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,5 +12,5 @@
     "strict": true,
     "target": "ES2017"
   },
-  "exclude": ["./dist/**/*"]
+  "exclude": ["./dist/**/*", "./src/**/*.test-d.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,5 +12,5 @@
     "strict": true,
     "target": "ES2017"
   },
-  "exclude": ["./dist/**/*", "./src/**/*.test-d.ts"]
+  "exclude": ["./dist/**/*"]
 }


### PR DESCRIPTION
The `hasProperty` function is now compatible with a wider variety of objects. The `Record<PropertyKey, unknown>` constraint used previously was exluding `Error`s, and any object-like things expressed as a custom class or interface. Now all of those are accepted.