### PR TITLE
BREAKING: Improve JSON validation

### DIFF
--- a/src/__fixtures__/json.ts
+++ b/src/__fixtures__/json.ts
@@ -1054,91 +1054,458 @@ export const JSON_RPC_PENDING_RESPONSE_FIXTURES = {
   ],
 };
 
-export const COMPLEX_OBJECT = {
-  data: {
-    account: {
-      typename: 'Account',
-      registrations: [
-        {
-          typename: 'Registration',
-          domain: {
-            typename: 'Domain',
-            isMigrated: true,
-            labelName: 'mycrypto',
-            labelhash:
-              '0x9a781ca0d227debc3ee76d547c960b0803a6c9f58c6d3b4722f12ede7e6ef7c9',
-            name: 'mycrypto.eth',
-            parent: { typename: 'Domain', name: 'eth' },
-          },
-          expiryDate: '1754111315',
-        },
-      ],
+/* eslint-disable @typescript-eslint/naming-convention */
+export const CHARACTER_MAP = {
+  '"': '\\"',
+  '\\': '\\\\',
+  '\x00': '\\u0000',
+  '\x01': '\\u0001',
+  '\x02': '\\u0002',
+  '\x03': '\\u0003',
+  '\x04': '\\u0004',
+  '\x05': '\\u0005',
+  '\x06': '\\u0006',
+  '\x07': '\\u0007',
+  '\x08': '\\b',
+  '\x09': '\\t',
+  '\x0A': '\\n',
+  '\x0B': '\\u000b',
+  '\x0C': '\\f',
+  '\x0D': '\\r',
+  '\x0E': '\\u000e',
+  '\x0F': '\\u000f',
+  '\x10': '\\u0010',
+  '\x11': '\\u0011',
+  '\x12': '\\u0012',
+  '\x13': '\\u0013',
+  '\x14': '\\u0014',
+  '\x15': '\\u0015',
+  '\x16': '\\u0016',
+  '\x17': '\\u0017',
+  '\x18': '\\u0018',
+  '\x19': '\\u0019',
+  '\x1A': '\\u001a',
+  '\x1B': '\\u001b',
+  '\x1C': '\\u001c',
+  '\x1D': '\\u001d',
+  '\x1E': '\\u001e',
+  '\x1F': '\\u001f',
+};
+/* eslint-enable @typescript-eslint/naming-convention */
+
+const DIRECT_CIRCULAR_REFERENCE_ARRAY: unknown[] = [];
+DIRECT_CIRCULAR_REFERENCE_ARRAY.push(DIRECT_CIRCULAR_REFERENCE_ARRAY);
+
+const INDIRECT_CIRCULAR_REFERENCE_ARRAY: unknown[] = [];
+INDIRECT_CIRCULAR_REFERENCE_ARRAY.push([[INDIRECT_CIRCULAR_REFERENCE_ARRAY]]);
+
+const DIRECT_CIRCULAR_REFERENCE_OBJECT: Record<string, unknown> = {};
+DIRECT_CIRCULAR_REFERENCE_OBJECT.prop = DIRECT_CIRCULAR_REFERENCE_OBJECT;
+
+const INDIRECT_CIRCULAR_REFERENCE_OBJECT: Record<string, unknown> = {
+  p1: {
+    p2: {
+      get p3() {
+        return INDIRECT_CIRCULAR_REFERENCE_OBJECT;
+      },
     },
-    moreComplexity: {
-      numbers: [
-        -5e-11, 5e-9, 0.000000000001, -0.00000000009, 100000.00000008,
-        -100.88888, 0.333, 1000000000000,
-      ],
-      moreNestedObjects: {
-        nestedAgain: {
-          nestedAgain: {
-            andAgain: {
-              andAgain: {
-                value: true,
-                again: {
-                  value: false,
+  },
+};
+
+const TO_JSON_CIRCULAR_REFERENCE = {
+  toJSON() {
+    return {};
+  },
+};
+
+const CIRCULAR_REFERENCE = { prop: TO_JSON_CIRCULAR_REFERENCE };
+TO_JSON_CIRCULAR_REFERENCE.toJSON = function () {
+  return CIRCULAR_REFERENCE;
+};
+
+const DUPLICATE_DATE = new Date();
+const DUPLICATE_OBJECT = {
+  value: 'foo',
+};
+
+const DUPLICATE_REFERENCE = {
+  a: DUPLICATE_DATE,
+  b: DUPLICATE_DATE,
+  c: DUPLICATE_DATE,
+  testOne: DUPLICATE_OBJECT,
+  testTwo: DUPLICATE_OBJECT,
+  testThree: {
+    nestedObjectTest: {
+      multipleTimes: {
+        valueOne: DUPLICATE_OBJECT,
+        valueTwo: DUPLICATE_OBJECT,
+        valueThree: DUPLICATE_OBJECT,
+        valueFour: DUPLICATE_OBJECT,
+        valueFive: DUPLICATE_DATE,
+        valueSix: {},
+      },
+    },
+  },
+  testFour: {},
+  testFive: {
+    something: null,
+    somethingElse: null,
+    anotherValue: null,
+    somethingAgain: DUPLICATE_OBJECT,
+    anotherOne: {
+      nested: {
+        multipleTimes: {
+          valueOne: DUPLICATE_OBJECT,
+        },
+      },
+    },
+  },
+};
+
+const REVOKED_ARRAY_PROXY = Proxy.revocable([], {});
+REVOKED_ARRAY_PROXY.revoke();
+
+const REVOKED_OBJECT_PROXY = Proxy.revocable({}, {});
+REVOKED_OBJECT_PROXY.revoke();
+
+export const JSON_VALIDATION_FIXTURES = [
+  {
+    value: {
+      a: 'bc',
+    },
+    valid: true,
+    size: 10,
+  },
+  {
+    value: {
+      a: 1234,
+    },
+    valid: true,
+    size: 10,
+  },
+  {
+    value: {
+      a: 'bcšečf',
+    },
+    valid: true,
+    size: 16,
+  },
+  {
+    value: [
+      -5e-11, 5e-9, 0.000000000001, -0.00000000009, 100000.00000008, -100.88888,
+      0.333, 1000000000000,
+    ],
+    valid: true,
+    size: 73,
+  },
+  {
+    value: {
+      data: {
+        account: {
+          /* eslint-disable @typescript-eslint/naming-convention */
+          __typename: 'Account',
+          registrations: [
+            {
+              __typename: 'Registration',
+              domain: {
+                __typename: 'Domain',
+                isMigrated: true,
+                labelName: 'mycrypto',
+                labelhash:
+                  '0x9a781ca0d227debc3ee76d547c960b0803a6c9f58c6d3b4722f12ede7e6ef7c9',
+                name: 'mycrypto.eth',
+                parent: { __typename: 'Domain', name: 'eth' },
+              },
+              expiryDate: '1754111315',
+            },
+          ],
+          /* eslint-enable @typescript-eslint/naming-convention */
+        },
+        moreComplexity: {
+          numbers: [
+            -5e-11, 5e-9, 0.000000000001, -0.00000000009, 100000.00000008,
+            -100.88888, 0.333, 1000000000000,
+          ],
+          moreNestedObjects: {
+            nestedAgain: {
+              nestedAgain: {
+                andAgain: {
+                  andAgain: {
+                    value: true,
+                    again: {
+                      value: false,
+                    },
+                  },
                 },
+              },
+            },
+          },
+          differentEncodings: {
+            ascii:
+              '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~',
+            utf8: 'šđćčžЀЂЇЄЖФћΣΩδλ',
+            mixed: 'ABCDEFGHIJ KLMNOPQRST UVWXYZšđćč žЀЂЇЄЖФћΣΩδλ',
+            specialCharacters: '"\\\n\r\t',
+            stringWithSpecialEscapedCharacters:
+              "this\nis\nsome\"'string\r\nwith\tspecial\\escaped\tcharacters'",
+          },
+          specialObjectsTypesAndValues: {
+            t: [true, true, true],
+            f: [false, false, false],
+            nulls: [null, null, null],
+            undef: null,
+            mixed: [
+              null,
+              null,
+              null,
+              null,
+              null,
+              true,
+              null,
+              false,
+              null,
+              null,
+            ],
+            inObject: {
+              valueOne: null,
+              valueTwo: null,
+              t: true,
+              f: false,
+            },
+            dates: {
+              someDate: new Date(),
+              someOther: new Date(2022, 0, 2, 15, 4, 5),
+              invalidDate: new Date('bad-date-format'),
+            },
+          },
+        },
+      },
+    },
+    valid: true,
+    size: 1288,
+  },
+  {
+    value: {
+      dates: {
+        someDate: new Date(),
+        someOther: new Date(2022, 0, 2, 15, 4, 5),
+        invalidDate: new Date('bad-date-format'),
+      },
+    },
+    valid: true,
+    size: 107,
+  },
+  {
+    value: ['foo', 'bar', null, ['foo', 'bar', null]],
+    valid: true,
+    size: 37,
+  },
+  {
+    value: null,
+    valid: true,
+    size: 4,
+  },
+  {
+    value: true,
+    valid: true,
+    size: 4,
+  },
+  {
+    value: false,
+    valid: true,
+    size: 5,
+  },
+  {
+    value: 'str',
+    valid: true,
+    size: 5,
+  },
+  {
+    value: 123,
+    valid: true,
+    size: 3,
+  },
+
+  {
+    value: {
+      a: undefined,
+    },
+    valid: false,
+    size: 0,
+  },
+  {
+    value: {
+      levelOne: {
+        levelTwo: {
+          levelThree: {
+            levelFour: {
+              levelFive: () => {
+                return 'anything';
               },
             },
           },
         },
       },
-      differentEncodings: {
-        ascii:
-          '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~',
-        utf8: 'šđćčžЀЂЇЄЖФћΣΩδλ',
-        mixed: 'ABCDEFGHIJ KLMNOPQRST UVWXYZšđćč žЀЂЇЄЖФћΣΩδλ',
-        specialCharacters: '"\\\n\r\t',
-        stringWithSpecialEscapedCharacters:
-          "this\nis\nsome\"'string\r\nwith\tspecial\\escaped\tcharacters'",
+    },
+    valid: false,
+    size: 0,
+  },
+  {
+    value: {
+      mySymbol: Symbol('MySymbol'),
+    },
+    valid: false,
+    size: 0,
+  },
+  {
+    value: [
+      function () {
+        return 'whatever';
       },
-      specialObjectsTypesAndValues: {
-        t: [true, true, true],
-        f: [false, false, false],
-        nulls: [null, null, null],
-        undef: null,
-        mixed: [null, null, null, null, null, true, null, false, null, null],
-        inObject: {
-          valueOne: null,
-          valueTwo: null,
-          t: true,
-          f: false,
-        },
-        dates: {
-          someDate: new Date(),
-          someOther: new Date(2022, 0, 2, 15, 4, 5),
-          invalidDate: new Date('bad-date-format'),
-        },
+    ],
+    valid: false,
+    size: 0,
+  },
+
+  // These tests are taken from ECMA TC39 (test262) test scenarios used for
+  // testing the `JSON.stringify` function.
+  // https://github.com/tc39/test262/tree/main/test/built-ins/JSON/stringify
+  /* eslint-disable no-new-wrappers */
+  {
+    value: new Boolean(true),
+    valid: true,
+    size: 4,
+  },
+  {
+    value: { key: new Boolean(false) },
+    valid: true,
+    size: 13,
+  },
+  {
+    value: new Boolean(false),
+    valid: true,
+    size: 5,
+  },
+  {
+    value: new Number(3.14),
+    valid: true,
+    size: 4,
+  },
+  {
+    value: new String('str'),
+    valid: true,
+    size: 5,
+  },
+  /* eslint-enable no-new-wrappers */
+  {
+    value: -0,
+    valid: true,
+    size: 1,
+  },
+  {
+    value: ['-0', 0, -0],
+    valid: true,
+    size: 10,
+  },
+  {
+    value: { key: -0 },
+    valid: true,
+    size: 9,
+  },
+  {
+    value: Infinity,
+    valid: false,
+    size: 0,
+  },
+  {
+    value: { key: -Infinity },
+    valid: false,
+    size: 0,
+  },
+  {
+    value: CHARACTER_MAP,
+    valid: true,
+    size: 593,
+  },
+  {
+    value: Object.keys(CHARACTER_MAP).join(''),
+    valid: true,
+    size: 178,
+  },
+  {
+    value: Object.keys(CHARACTER_MAP).reverse().join(''),
+    valid: true,
+    size: 178,
+  },
+  {
+    value: Object.values(CHARACTER_MAP).join(''),
+    valid: true,
+    size: 214,
+  },
+  {
+    value: Object.values(CHARACTER_MAP).reverse().join(''),
+    valid: true,
+    size: 214,
+  },
+  {
+    value: {
+      toJSON: null,
+    },
+    valid: true,
+    size: 15,
+  },
+  {
+    value: { toJSON: false },
+    valid: true,
+    size: 16,
+  },
+  {
+    value: { toJSON: [] },
+    valid: true,
+    size: 13,
+  },
+  {
+    value: DUPLICATE_REFERENCE,
+    valid: true,
+    size: 552,
+  },
+  {
+    value: { a: { b: REVOKED_OBJECT_PROXY.proxy } },
+    valid: false,
+    size: 0,
+  },
+  {
+    value: {
+      get key() {
+        throw new Error();
       },
     },
+    valid: false,
+    size: 0,
   },
-};
-
-export const NON_SERIALIZABLE_NESTED_OBJECT = {
-  levelOne: {
-    levelTwo: {
-      levelThree: {
-        levelFour: {
-          levelFive: () => {
-            return 'anything';
-          },
-        },
-      },
-    },
+  {
+    value: undefined,
+    valid: false,
+    size: 0,
   },
-};
-
-export const ARRAY_OF_DIFFRENT_KINDS_OF_NUMBERS = [
-  -5e-11, 5e-9, 0.000000000001, -0.00000000009, 100000.00000008, -100.88888,
-  0.333, 1000000000000,
+  {
+    value: DIRECT_CIRCULAR_REFERENCE_ARRAY,
+    valid: false,
+    size: 0,
+  },
+  {
+    value: INDIRECT_CIRCULAR_REFERENCE_ARRAY,
+    valid: false,
+    size: 0,
+  },
+  {
+    value: DIRECT_CIRCULAR_REFERENCE_OBJECT,
+    valid: false,
+    size: 0,
+  },
+  {
+    value: INDIRECT_CIRCULAR_REFERENCE_OBJECT,
+    valid: false,
+    size: 0,
+  },
 ];

--- a/src/__fixtures__/json.ts
+++ b/src/__fixtures__/json.ts
@@ -5,13 +5,7 @@ export const JSON_FIXTURES = {
     ['a', 2, null],
     [{ a: null, b: 2, c: [{ foo: 'bar' }] }],
   ],
-  invalid: [
-    undefined,
-    Symbol('bar'),
-    Promise.resolve(),
-    () => 'foo',
-    [{ a: undefined }],
-  ],
+  invalid: [undefined, Symbol('bar'), () => 'foo', [{ a: undefined }]],
 };
 
 export const JSON_RPC_NOTIFICATION_FIXTURES = {

--- a/src/json.test.ts
+++ b/src/json.test.ts
@@ -52,7 +52,9 @@ describe('json', () => {
     it('returns error message', () => {
       const [error] = validate(undefined, JsonStruct);
       assert(error !== undefined);
-      expect(error.message).toBe('Expected a valid JSON-serializable value');
+      expect(error.message).toBe(
+        'Expected the value to satisfy a union of `literal | boolean | number | string | array | record`, but received: undefined',
+      );
     });
   });
 

--- a/src/json.test.ts
+++ b/src/json.test.ts
@@ -1,4 +1,11 @@
-import { validate, assert as superstructAssert } from 'superstruct';
+import {
+  validate,
+  assert as superstructAssert,
+  is,
+  literal,
+  union,
+  number,
+} from 'superstruct';
 
 import {
   assert,
@@ -10,6 +17,7 @@ import {
   assertIsJsonRpcSuccess,
   assertIsPendingJsonRpcResponse,
   getJsonRpcIdValidator,
+  getJsonSize,
   isJsonRpcError,
   isJsonRpcFailure,
   isJsonRpcNotification,
@@ -19,11 +27,8 @@ import {
   isPendingJsonRpcResponse,
   isValidJson,
   JsonStruct,
-  validateJsonAndGetSize,
 } from '.';
 import {
-  ARRAY_OF_DIFFRENT_KINDS_OF_NUMBERS,
-  COMPLEX_OBJECT,
   JSON_FIXTURES,
   JSON_RPC_ERROR_FIXTURES,
   JSON_RPC_FAILURE_FIXTURES,
@@ -32,7 +37,7 @@ import {
   JSON_RPC_REQUEST_FIXTURES,
   JSON_RPC_RESPONSE_FIXTURES,
   JSON_RPC_SUCCESS_FIXTURES,
-  NON_SERIALIZABLE_NESTED_OBJECT,
+  JSON_VALIDATION_FIXTURES,
 } from './__fixtures__';
 
 jest.mock('superstruct', () => ({
@@ -53,24 +58,36 @@ describe('json', () => {
       const [error] = validate(undefined, JsonStruct);
       assert(error !== undefined);
       expect(error.message).toBe(
-        'Expected the value to satisfy a union of `literal | boolean | number | string | array | record`, but received: undefined',
+        'Expected the value to satisfy a union of `literal | boolean | finite number | string | array | record`, but received: undefined',
       );
     });
   });
 
-  // TODO: Make this test suite exhaustive.
-  // The current implementation is guaranteed to be correct, but in the future
-  // we may opt for a bespoke implementation that is more performant, but may
-  // contain bugs.
   describe('isValidJson', () => {
     it.each(JSON_FIXTURES.valid)('identifies valid JSON values', (value) => {
       expect(isValidJson(value)).toBe(true);
     });
 
+    it.each(JSON_VALIDATION_FIXTURES)(
+      'works on complex object %o',
+      ({ value, valid }) => {
+        expect(isValidJson(value)).toBe(valid);
+      },
+    );
+
     it.each(JSON_FIXTURES.invalid)(
       'identifies invalid JSON values',
       (value) => {
         expect(isValidJson(value)).toBe(false);
+      },
+    );
+  });
+
+  describe('getJsonSize', () => {
+    it.each(JSON_VALIDATION_FIXTURES.filter((fixture) => fixture.valid))(
+      'returns the size of %o',
+      ({ value, size }) => {
+        expect(getJsonSize(value)).toBe(size);
       },
     );
   });
@@ -529,542 +546,6 @@ describe('json', () => {
           inputs,
         ),
       ).not.toThrow();
-    });
-  });
-
-  describe('validateJsonAndGetSize', () => {
-    it('should return true for serialization and 10 for a size', () => {
-      const valueToSerialize = {
-        a: 'bc',
-      };
-
-      expect(validateJsonAndGetSize(valueToSerialize)).toStrictEqual([
-        true,
-        10,
-      ]);
-    });
-
-    it('should return true for serialization and 11 for a size', () => {
-      const valueToSerialize = {
-        a: 1234,
-      };
-
-      expect(validateJsonAndGetSize(valueToSerialize)).toStrictEqual([
-        true,
-        10,
-      ]);
-    });
-
-    it('should return true for serialization and 16 for a size when mixed UTF8 and ASCII values are used', () => {
-      const valueToSerialize = {
-        a: 'bcšečf',
-      };
-
-      expect(validateJsonAndGetSize(valueToSerialize)).toStrictEqual([
-        true,
-        16,
-      ]);
-    });
-
-    it('should return false for serialization and 0 for a size when only one key with undefined value is provided', () => {
-      const valueToSerialize = {
-        a: undefined,
-      };
-
-      expect(validateJsonAndGetSize(valueToSerialize)).toStrictEqual([
-        false,
-        0,
-      ]);
-    });
-
-    it('should return true for serialization and 73 for a size, for an array of numbers', () => {
-      expect(
-        validateJsonAndGetSize(ARRAY_OF_DIFFRENT_KINDS_OF_NUMBERS),
-      ).toStrictEqual([true, 73]);
-    });
-
-    it('should return true for serialization and 1280 for a size of a complex nested object', () => {
-      expect(validateJsonAndGetSize(COMPLEX_OBJECT)).toStrictEqual([
-        true,
-        1280,
-      ]);
-    });
-
-    it('should return true for serialization and 107 for a size of an object containing Date object', () => {
-      const dateObjects = {
-        dates: {
-          someDate: new Date(),
-          someOther: new Date(2022, 0, 2, 15, 4, 5),
-          invalidDate: new Date('bad-date-format'),
-        },
-      };
-      expect(validateJsonAndGetSize(dateObjects)).toStrictEqual([true, 107]);
-    });
-
-    it('should return false for serialization and 0 for size when non-serializable nested object was provided', () => {
-      expect(
-        NON_SERIALIZABLE_NESTED_OBJECT.levelOne.levelTwo.levelThree.levelFour.levelFive(),
-      ).toBe('anything');
-
-      expect(
-        validateJsonAndGetSize(NON_SERIALIZABLE_NESTED_OBJECT),
-      ).toStrictEqual([false, 0]);
-    });
-
-    it('should return true for serialization and 0 for a size when sizing is skipped', () => {
-      expect(validateJsonAndGetSize(COMPLEX_OBJECT, true)).toStrictEqual([
-        true,
-        0,
-      ]);
-    });
-
-    it('should return false for serialization and 0 for a size when sizing is skipped and non-serializable object was provided', () => {
-      expect(
-        validateJsonAndGetSize(NON_SERIALIZABLE_NESTED_OBJECT, true),
-      ).toStrictEqual([false, 0]);
-    });
-
-    it('should return false for serialization and 0 for a size when checking object containing symbols', () => {
-      const objectContainingSymbols = {
-        mySymbol: Symbol('MySymbol'),
-      };
-      expect(validateJsonAndGetSize(objectContainingSymbols)).toStrictEqual([
-        false,
-        0,
-      ]);
-    });
-
-    it('should return false for serialization and 0 for a size when checking an array containing a function', () => {
-      const objectContainingFunction = [
-        function () {
-          return 'whatever';
-        },
-      ];
-      expect(validateJsonAndGetSize(objectContainingFunction)).toStrictEqual([
-        false,
-        0,
-      ]);
-    });
-
-    it('returns true for serialization and 37 for a size when checking an array', () => {
-      expect(
-        validateJsonAndGetSize(['foo', 'bar', null, ['foo', 'bar', null]]),
-      ).toStrictEqual([true, 37]);
-    });
-
-    it('should return true or false for validity depending on the test scenario from ECMA TC39 (test262)', () => {
-      // This test will perform a series of validation assertions.
-      // These tests are taken from ECMA TC39 (test262) test scenarios used
-      // for testing the JSON.stringify function.
-      // https://github.com/tc39/test262/tree/main/test/built-ins/JSON/stringify
-
-      // Value: array proxy revoked
-      const handle = Proxy.revocable([], {});
-      handle.revoke();
-
-      expect(validateJsonAndGetSize(handle.proxy)).toStrictEqual([false, 0]);
-      expect(validateJsonAndGetSize([[[handle.proxy]]])).toStrictEqual([
-        false,
-        0,
-      ]);
-
-      // Value: array proxy
-      const arrayProxy = new Proxy([], {
-        get(_target, key) {
-          if (key === 'length') {
-            return 2;
-          }
-          return Number(key);
-        },
-      });
-
-      expect(validateJsonAndGetSize(arrayProxy, true)).toStrictEqual([true, 0]);
-
-      expect(validateJsonAndGetSize([[arrayProxy]], true)).toStrictEqual([
-        true,
-        0,
-      ]);
-
-      const arrayProxyProxy = new Proxy(arrayProxy, {});
-      expect(validateJsonAndGetSize([[arrayProxyProxy]], true)).toStrictEqual([
-        true,
-        0,
-      ]);
-
-      // Value: Boolean object
-      // eslint-disable-next-line no-new-wrappers
-      expect(validateJsonAndGetSize(new Boolean(true), true)).toStrictEqual([
-        true,
-        0,
-      ]);
-
-      expect(
-        // eslint-disable-next-line no-new-wrappers
-        validateJsonAndGetSize({ key: new Boolean(false) }, true),
-      ).toStrictEqual([true, 0]);
-
-      expect(
-        // eslint-disable-next-line no-new-wrappers
-        validateJsonAndGetSize(new Boolean(false)),
-      ).toStrictEqual([true, 5]);
-
-      expect(
-        // eslint-disable-next-line no-new-wrappers
-        validateJsonAndGetSize(new Boolean(true)),
-      ).toStrictEqual([true, 4]);
-
-      // Value: number negative zero
-      expect(validateJsonAndGetSize(-0, true)).toStrictEqual([true, 0]);
-      expect(validateJsonAndGetSize(['-0', 0, -0], true)).toStrictEqual([
-        true,
-        0,
-      ]);
-
-      expect(validateJsonAndGetSize({ key: -0 }, true)).toStrictEqual([
-        true,
-        0,
-      ]);
-
-      // Value: number non finite
-      expect(validateJsonAndGetSize(Infinity, true)).toStrictEqual([true, 0]);
-      expect(validateJsonAndGetSize({ key: -Infinity }, true)).toStrictEqual([
-        true,
-        0,
-      ]);
-      expect(validateJsonAndGetSize([NaN], true)).toStrictEqual([true, 0]);
-
-      // Value: object abrupt
-      expect(
-        validateJsonAndGetSize(
-          {
-            get key() {
-              throw new Error();
-            },
-          },
-          true,
-        ),
-      ).toStrictEqual([false, 0]);
-
-      // Value: Number object
-      // eslint-disable-next-line no-new-wrappers
-      expect(validateJsonAndGetSize(new Number(3.14), true)).toStrictEqual([
-        true,
-        0,
-      ]);
-
-      // eslint-disable-next-line no-new-wrappers
-      expect(validateJsonAndGetSize(new Number(3.14))).toStrictEqual([true, 4]);
-
-      // Value: object proxy
-      const objectProxy = new Proxy(
-        {},
-        {
-          getOwnPropertyDescriptor() {
-            return {
-              value: 1,
-              writable: true,
-              enumerable: true,
-              configurable: true,
-            };
-          },
-          get() {
-            return 1;
-          },
-          ownKeys() {
-            return ['a', 'b'];
-          },
-        },
-      );
-
-      expect(validateJsonAndGetSize(objectProxy, true)).toStrictEqual([
-        true,
-        0,
-      ]);
-
-      expect(
-        validateJsonAndGetSize({ l1: { l2: objectProxy } }, true),
-      ).toStrictEqual([true, 0]);
-
-      // Value: object proxy revoked
-      const handleForObjectProxy = Proxy.revocable({}, {});
-      handleForObjectProxy.revoke();
-      expect(
-        validateJsonAndGetSize(handleForObjectProxy.proxy, true),
-      ).toStrictEqual([false, 0]);
-
-      expect(
-        validateJsonAndGetSize({ a: { b: handleForObjectProxy.proxy } }, true),
-      ).toStrictEqual([false, 0]);
-
-      // Value: primitive top level
-      expect(validateJsonAndGetSize(null, true)).toStrictEqual([true, 0]);
-      expect(validateJsonAndGetSize(true, true)).toStrictEqual([true, 0]);
-      expect(validateJsonAndGetSize(false, true)).toStrictEqual([true, 0]);
-      expect(validateJsonAndGetSize('str', true)).toStrictEqual([true, 0]);
-      expect(validateJsonAndGetSize(123, true)).toStrictEqual([true, 0]);
-      expect(validateJsonAndGetSize(undefined, true)).toStrictEqual([false, 0]);
-
-      /* eslint-disable @typescript-eslint/naming-convention */
-      // Value: string escape ASCII
-      const charToJson = {
-        '"': '\\"',
-        '\\': '\\\\',
-        '\x00': '\\u0000',
-        '\x01': '\\u0001',
-        '\x02': '\\u0002',
-        '\x03': '\\u0003',
-        '\x04': '\\u0004',
-        '\x05': '\\u0005',
-        '\x06': '\\u0006',
-        '\x07': '\\u0007',
-        '\x08': '\\b',
-        '\x09': '\\t',
-        '\x0A': '\\n',
-        '\x0B': '\\u000b',
-        '\x0C': '\\f',
-        '\x0D': '\\r',
-        '\x0E': '\\u000e',
-        '\x0F': '\\u000f',
-        '\x10': '\\u0010',
-        '\x11': '\\u0011',
-        '\x12': '\\u0012',
-        '\x13': '\\u0013',
-        '\x14': '\\u0014',
-        '\x15': '\\u0015',
-        '\x16': '\\u0016',
-        '\x17': '\\u0017',
-        '\x18': '\\u0018',
-        '\x19': '\\u0019',
-        '\x1A': '\\u001a',
-        '\x1B': '\\u001b',
-        '\x1C': '\\u001c',
-        '\x1D': '\\u001d',
-        '\x1E': '\\u001e',
-        '\x1F': '\\u001f',
-      };
-      /* eslint-enable @typescript-eslint/naming-convention */
-
-      const chars = Object.keys(charToJson).join('');
-      const charsReversed = Object.keys(charToJson).reverse().join('');
-      const jsonChars = Object.values(charToJson).join('');
-      const jsonCharsReversed = Object.values(charToJson).reverse().join('');
-
-      expect(validateJsonAndGetSize(charToJson, true)).toStrictEqual([true, 0]);
-
-      // eslint-disable-next-line guard-for-in
-      for (const char in charToJson) {
-        expect(validateJsonAndGetSize(char, true)).toStrictEqual([true, 0]);
-      }
-
-      expect(validateJsonAndGetSize(chars, true)).toStrictEqual([true, 0]);
-      expect(validateJsonAndGetSize(charsReversed, true)).toStrictEqual([
-        true,
-        0,
-      ]);
-      expect(validateJsonAndGetSize(jsonChars, true)).toStrictEqual([true, 0]);
-      expect(validateJsonAndGetSize(jsonCharsReversed, true)).toStrictEqual([
-        true,
-        0,
-      ]);
-
-      // Value: string escape unicode
-      const stringEscapeUnicode: string[] = [
-        '\uD834',
-        '\uDF06',
-        '\uD834\uDF06',
-        '\uD834\uD834\uDF06\uD834',
-        '\uD834\uD834\uDF06\uDF06',
-        '\uDF06\uD834\uDF06\uD834',
-        '\uDF06\uD834\uDF06\uDF06',
-        '\uDF06\uD834',
-        '\uD834\uDF06\uD834\uD834',
-        '\uD834\uDF06\uD834\uDF06',
-        '\uDF06\uDF06\uD834\uD834',
-        '\uDF06\uDF06\uD834\uDF06',
-      ];
-
-      // eslint-disable-next-line guard-for-in
-      for (const strUnicode of stringEscapeUnicode) {
-        expect(validateJsonAndGetSize(strUnicode, true)).toStrictEqual([
-          true,
-          0,
-        ]);
-      }
-
-      // Value: string object
-      // eslint-disable-next-line no-new-wrappers
-      expect(validateJsonAndGetSize(new String('str'), true)).toStrictEqual([
-        true,
-        0,
-      ]);
-
-      // eslint-disable-next-line no-new-wrappers
-      expect(validateJsonAndGetSize(new String('str'))).toStrictEqual([
-        true,
-        5,
-      ]);
-
-      // Value: toJSON not a function
-      expect(validateJsonAndGetSize({ toJSON: null }, true)).toStrictEqual([
-        true,
-        0,
-      ]);
-
-      expect(validateJsonAndGetSize({ toJSON: false }, true)).toStrictEqual([
-        true,
-        0,
-      ]);
-
-      expect(validateJsonAndGetSize({ toJSON: [] }, true)).toStrictEqual([
-        true,
-        0,
-      ]);
-
-      // Value: array circular
-      const direct: unknown[] = [];
-      direct.push(direct);
-
-      expect(validateJsonAndGetSize(direct)).toStrictEqual([false, 0]);
-
-      const indirect: unknown[] = [];
-      indirect.push([[indirect]]);
-
-      expect(validateJsonAndGetSize(indirect)).toStrictEqual([false, 0]);
-
-      // Value: object circular
-      const directObject = { prop: {} };
-      directObject.prop = directObject;
-
-      expect(validateJsonAndGetSize(directObject, false)).toStrictEqual([
-        false,
-        0,
-      ]);
-
-      const indirectObject = {
-        p1: {
-          p2: {
-            get p3() {
-              return indirectObject;
-            },
-          },
-        },
-      };
-
-      expect(validateJsonAndGetSize(indirectObject, false)).toStrictEqual([
-        false,
-        0,
-      ]);
-
-      // Value: toJSON object circular
-      const obj = {
-        toJSON() {
-          return {};
-        },
-      };
-      const circular = { prop: obj };
-
-      obj.toJSON = function () {
-        return circular;
-      };
-
-      expect(validateJsonAndGetSize(circular, true)).toStrictEqual([false, 0]);
-    });
-
-    it('should return false for validation for an object that contains nested circular references', () => {
-      const circularStructure = {
-        levelOne: {
-          levelTwo: {
-            levelThree: {
-              levelFour: {
-                levelFive: {},
-              },
-            },
-          },
-        },
-      };
-      circularStructure.levelOne.levelTwo.levelThree.levelFour.levelFive =
-        circularStructure;
-
-      expect(validateJsonAndGetSize(circularStructure, false)).toStrictEqual([
-        false,
-        0,
-      ]);
-    });
-
-    it('should return false for an object that contains multiple nested circular references', () => {
-      const circularStructure = {
-        levelOne: {
-          levelTwo: {
-            levelThree: {
-              levelFour: {
-                levelFive: {},
-              },
-            },
-          },
-        },
-        anotherOne: {},
-        justAnotherOne: {
-          toAnotherOne: {
-            andAnotherOne: {},
-          },
-        },
-      };
-      circularStructure.levelOne.levelTwo.levelThree.levelFour.levelFive =
-        circularStructure;
-      circularStructure.anotherOne = circularStructure;
-      circularStructure.justAnotherOne.toAnotherOne.andAnotherOne =
-        circularStructure;
-
-      expect(validateJsonAndGetSize(circularStructure)).toStrictEqual([
-        false,
-        0,
-      ]);
-    });
-
-    it('should return true for validity for an object that contains the same object multiple times', () => {
-      // This will test if false positives are removed from the circular reference detection
-      const date = new Date();
-      const testObject = {
-        value: 'whatever',
-      };
-      const objectToTest = {
-        a: date,
-        b: date,
-        c: date,
-        testOne: testObject,
-        testTwo: testObject,
-        testThree: {
-          nestedObjectTest: {
-            multipleTimes: {
-              valueOne: testObject,
-              valueTwo: testObject,
-              valueThree: testObject,
-              valueFour: testObject,
-              valueFive: date,
-              valueSix: {},
-            },
-          },
-        },
-        testFour: {},
-        testFive: {
-          something: null,
-          somethingElse: null,
-          anotherValue: null,
-          somethingAgain: testObject,
-          anotherOne: {
-            nested: {
-              multipleTimes: {
-                valueOne: testObject,
-              },
-            },
-          },
-        },
-      };
-
-      expect(validateJsonAndGetSize(objectToTest, true)).toStrictEqual([
-        true,
-        0,
-      ]);
     });
   });
 });

--- a/src/json.test.ts
+++ b/src/json.test.ts
@@ -1,11 +1,4 @@
-import {
-  validate,
-  assert as superstructAssert,
-  is,
-  literal,
-  union,
-  number,
-} from 'superstruct';
+import { validate, assert as superstructAssert } from 'superstruct';
 
 import {
   assert,

--- a/src/json.ts
+++ b/src/json.ts
@@ -1,6 +1,5 @@
 import {
   array,
-  assert,
   boolean,
   define,
   Infer,
@@ -21,12 +20,6 @@ import {
 } from 'superstruct';
 
 import { AssertionErrorConstructor, assertStruct } from './assert';
-import {
-  calculateNumberSize,
-  calculateStringSize,
-  isPlainObject,
-  JsonSize,
-} from './misc';
 
 /**
  * Any JSON-compatible value.
@@ -40,6 +33,17 @@ export type Json =
   | { [prop: string]: Json };
 
 /**
+ * A struct to check if the given value is finite number. Superstruct's
+ * `number()` struct does not check if the value is finite.
+ *
+ * @returns A struct to check if the given value is finite number.
+ */
+const finiteNumber = () =>
+  define<number>('finite number', (value) => {
+    return is(value, number()) && Number.isFinite(value);
+  });
+
+/**
  * A struct to check if the given value is a valid JSON-serializable value.
  *
  * Note that this struct is unsafe. For safe validation, use {@link JsonStruct}.
@@ -48,7 +52,7 @@ export type Json =
 export const UnsafeJsonStruct: Struct<Json> = union([
   literal(null),
   boolean(),
-  number(),
+  finiteNumber(),
   string(),
   array(lazy(() => UnsafeJsonStruct)),
   record(
@@ -83,24 +87,32 @@ export const JsonStruct = define<Json>('Json', (value, context) => {
     return true;
   }
 
-  // The plain value must be a valid JSON value, but it may be altered in the
-  // process of JSON serialization, so we need to validate it again after
-  // serialization. This has the added benefit that the returned error messages
-  // will be more helpful, as they will point to the exact location of the
-  // invalid value.
-  //
-  // This seems overcomplicated, but without checking the plain value first,
-  // there are some cases where the validation passes, even though the value is
-  // not valid JSON. For example, `undefined` is not valid JSON, but serializing
-  // it will remove it from the object, so the validation will pass.
-  const unsafeResult = checkStruct(value, UnsafeJsonStruct);
-  if (unsafeResult !== true) {
-    return unsafeResult;
-  }
+  try {
+    // The plain value must be a valid JSON value, but it may be altered in the
+    // process of JSON serialization, so we need to validate it again after
+    // serialization. This has the added benefit that the returned error messages
+    // will be more helpful, as they will point to the exact location of the
+    // invalid value.
+    //
+    // This seems overcomplicated, but without checking the plain value first,
+    // there are some cases where the validation passes, even though the value is
+    // not valid JSON. For example, `undefined` is not valid JSON, but serializing
+    // it will remove it from the object, so the validation will pass.
+    const unsafeResult = checkStruct(value, UnsafeJsonStruct);
+    if (unsafeResult !== true) {
+      return unsafeResult;
+    }
 
-  // JavaScript engines are highly optimized for this specific use case of
-  // JSON parsing and stringifying, so there should be no performance impact.
-  return checkStruct(JSON.parse(JSON.stringify(value)), UnsafeJsonStruct);
+    // JavaScript engines are highly optimized for this specific use case of
+    // JSON parsing and stringifying, so there should be no performance impact.
+    return checkStruct(JSON.parse(JSON.stringify(value)), UnsafeJsonStruct);
+  } catch (error) {
+    if (error instanceof RangeError) {
+      return 'Circular reference detected';
+    }
+
+    return false;
+  }
 });
 
 /**
@@ -554,144 +566,4 @@ export function getJsonRpcIdValidator(options?: JsonRpcValidatorOptions) {
   };
 
   return isValidJsonRpcId;
-}
-
-/**
- * Checks whether a value is JSON serializable and counts the total number
- * of bytes needed to store the serialized version of the value.
- *
- * @param jsObject - Potential JSON serializable object.
- * @param skipSizingProcess - Skip JSON size calculation (default: false).
- * @returns Tuple [isValid, plainTextSizeInBytes] containing a boolean that signals whether
- * the value was serializable and a number of bytes that it will use when serialized to JSON.
- */
-export function validateJsonAndGetSize(
-  jsObject: unknown,
-  skipSizingProcess = false,
-): [isValid: boolean, plainTextSizeInBytes: number] {
-  const seenObjects = new Set();
-  /**
-   * Checks whether a value is JSON serializable and counts the total number
-   * of bytes needed to store the serialized version of the value.
-   *
-   * This function assumes the encoding of the JSON is done in UTF-8.
-   *
-   * @param value - Potential JSON serializable value.
-   * @param skipSizing - Skip JSON size calculation (default: false).
-   * @returns Tuple [isValid, plainTextSizeInBytes] containing a boolean that signals whether
-   * the value was serializable and a number of bytes that it will use when serialized to JSON.
-   */
-  function getJsonSerializableInfo(
-    value: unknown,
-    skipSizing: boolean,
-  ): [isValid: boolean, plainTextSizeInBytes: number] {
-    if (value === undefined) {
-      return [false, 0];
-    } else if (value === null) {
-      // Return already specified constant size for null (special object)
-      return [true, skipSizing ? 0 : JsonSize.Null];
-    }
-
-    // Check and calculate sizes for basic (and some special) types
-    const typeOfValue = typeof value;
-    try {
-      if (typeOfValue === 'function') {
-        return [false, 0];
-      } else if (typeOfValue === 'string' || value instanceof String) {
-        return [
-          true,
-          skipSizing
-            ? 0
-            : calculateStringSize(value as string) + JsonSize.Quote * 2,
-        ];
-      } else if (typeOfValue === 'boolean' || value instanceof Boolean) {
-        if (skipSizing) {
-          return [true, 0];
-        }
-        // eslint-disable-next-line eqeqeq
-        return [true, value == true ? JsonSize.True : JsonSize.False];
-      } else if (typeOfValue === 'number' || value instanceof Number) {
-        if (skipSizing) {
-          return [true, 0];
-        }
-        return [true, calculateNumberSize(value as number)];
-      } else if (value instanceof Date) {
-        if (skipSizing) {
-          return [true, 0];
-        }
-        return [
-          true,
-          // Note: Invalid dates will serialize to null
-          isNaN(value.getDate())
-            ? JsonSize.Null
-            : JsonSize.Date + JsonSize.Quote * 2,
-        ];
-      }
-    } catch (_) {
-      return [false, 0];
-    }
-
-    // If object is not plain and cannot be serialized properly,
-    // stop here and return false for serialization
-    if (!isPlainObject(value) && !Array.isArray(value)) {
-      return [false, 0];
-    }
-
-    // Circular object detection (handling)
-    // Check if the same object already exists
-    if (seenObjects.has(value)) {
-      return [false, 0];
-    }
-    // Add new object to the seen objects set
-    // Only the plain objects should be added (Primitive types are skipped)
-    seenObjects.add(value);
-
-    // Continue object decomposition
-    try {
-      return [
-        true,
-        Object.entries(value).reduce(
-          (sum, [key, nestedValue], idx, arr) => {
-            // Recursively process next nested object or primitive type
-            // eslint-disable-next-line prefer-const
-            let [valid, size] = getJsonSerializableInfo(
-              nestedValue,
-              skipSizing,
-            );
-            if (!valid) {
-              throw new Error(
-                'JSON validation did not pass. Validation process stopped.',
-              );
-            }
-
-            // Circular object detection
-            // Once a child node is visited and processed remove it from the set.
-            // This will prevent false positives with the same adjacent objects.
-            seenObjects.delete(value);
-
-            if (skipSizing) {
-              return 0;
-            }
-
-            // Objects will have be serialized with "key": value,
-            // therefore we include the key in the calculation here
-            const keySize = Array.isArray(value)
-              ? 0
-              : key.length + JsonSize.Comma + JsonSize.Colon * 2;
-
-            const separator = idx < arr.length - 1 ? JsonSize.Comma : 0;
-
-            return sum + keySize + size + separator;
-          },
-          // Starts at 2 because the serialized JSON string data (plain text)
-          // will minimally contain {}/[]
-          skipSizing ? 0 : JsonSize.Wrapper * 2,
-        ),
-      ];
-    } catch (_) {
-      return [false, 0];
-    }
-  }
-
-  return getJsonSerializableInfo(jsObject, skipSizingProcess);
 }


### PR DESCRIPTION
Closes MetaMask/MetaMask-planning#327.

This fixes edge cases in our JSON validation logic.

## Breaking changes

- The previous function used for JSON validation, `validateJsonAndGetSize` was removed.
   - The `isValidJson` function now uses the new JSON validation logic.
   - To get the size of a JSON value, you can use the `getJsonSize` function.