### PR TITLE
Keep original type when using `hasProperty` if defined

### DIFF
--- a/src/misc.test-d.ts
+++ b/src/misc.test-d.ts
@@ -89,6 +89,16 @@ class HasPropertyClassExample {
 const hasPropertyClassExample = new HasPropertyClassExample();
 hasProperty(hasPropertyClassExample, 'a');
 
+type HasPropertyTypeExample = {
+  a?: number;
+};
+
+// It keeps the original type when defined.
+const hasPropertyTypeExample: HasPropertyTypeExample = {};
+if (hasProperty(hasPropertyTypeExample, 'a')) {
+  expectType<number | undefined>(hasPropertyTypeExample.a);
+}
+
 //=============================================================================
 // RuntimeObject
 //=============================================================================

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -93,8 +93,11 @@ export const hasProperty = <
 >(
   objectToCheck: ObjectToCheck,
   name: Property,
-): objectToCheck is ObjectToCheck & Record<Property, unknown> =>
-  Object.hasOwnProperty.call(objectToCheck, name);
+): objectToCheck is ObjectToCheck &
+  Record<
+    Property,
+    Property extends keyof ObjectToCheck ? ObjectToCheck[Property] : unknown
+  > => Object.hasOwnProperty.call(objectToCheck, name);
 
 export type PlainObject = Record<number | string | symbol, unknown>;
 


### PR DESCRIPTION
Rather than asserting that the property is `unknown`, this checks if the object has the property defined, and asserts that type instead.