### PR TITLE
Strip `__proto__` and `constructor` JSON properties in `getSafeJson`

### DIFF
--- a/src/json.test.ts
+++ b/src/json.test.ts
@@ -88,6 +88,13 @@ describe('json', () => {
       // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(descriptor?.set).toBeUndefined();
     });
+
+    it('strips __proto__ and constructor', () => {
+      const input =
+        '{ "test": { "__proto__": { "foo": "bar" } }, "test2": { "constructor": { "baz": "qux" } } }';
+      const parsed = JSON.parse(input);
+      expect(getSafeJson(parsed)).toStrictEqual({ test: {}, test2: {} });
+    });
   });
 
   describe('isValidJson', () => {

--- a/src/json.ts
+++ b/src/json.ts
@@ -72,7 +72,15 @@ export const UnsafeJsonStruct: Struct<Json> = union([
  */
 export const JsonStruct = coerce(UnsafeJsonStruct, any(), (value) => {
   assertStruct(value, UnsafeJsonStruct);
-  return JSON.parse(JSON.stringify(value));
+  return JSON.parse(
+    JSON.stringify(value, (propKey, propValue) => {
+      // Strip __proto__ and constructor properties to prevent prototype pollution.
+      if (propKey === '__proto__' || propKey === 'constructor') {
+        return undefined;
+      }
+      return propValue;
+    }),
+  );
 });
 
 /**


### PR DESCRIPTION
Strip `__proto__` and `constructor` JSON properties from inputs to `getSafeJson`.