### PR TITLE
Add optional `destroy` method to `Keyring` type

### DIFF
--- a/src/keyring.ts
+++ b/src/keyring.ts
@@ -258,4 +258,9 @@ export type Keyring<State extends Json> = {
    * BIP39-compliant mnemonic.
    */
   generateRandomMnemonic?(): void;
+
+  /**
+   * Destroy the keyring.
+   */
+  destroy?(): Promise<void>;
 };


### PR DESCRIPTION
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

This PR adds the `destroy` optional method to the `Keyring` type.
Some keyrings like `@metamask/eth-trezor-keyring` and `@metamask/eth-ledger-bridge-keyring` support this method to remove hardware bridges and in some cases (Ledger) to remove listeners.

We need to add this method to the `Keyring` before migrating Trezor and Ledger keyrings to this type.

* Fixes #107
