### PR TITLE
Bump semver to ensure signed provenance, CVE fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@noble/hashes": "^1.3.1",
     "@types/debug": "^4.1.7",
     "debug": "^4.3.4",
-    "semver": "^7.3.8",
+    "semver": "^7.5.4",
     "superstruct": "^1.0.3"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1123,7 +1123,7 @@ __metadata:
     prettier: ^2.7.1
     prettier-plugin-packagejson: ^2.3.0
     rimraf: ^3.0.2
-    semver: ^7.3.8
+    semver: ^7.5.4
     stdio-mock: ^1.2.0
     superstruct: ^1.0.3
     ts-jest: ^29.0.3
@@ -6974,7 +6974,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:7.x, semver@npm:^7.0.0, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.3.8, semver@npm:^7.5.3":
+"semver@npm:7.x, semver@npm:^7.0.0, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.3.8, semver@npm:^7.5.3, semver@npm:^7.5.4":
   version: 7.5.4
   resolution: "semver@npm:7.5.4"
   dependencies:


### PR DESCRIPTION
Problem: Many snaps recently audited used vulnerable package during audits/reviews.

Solutions: Bumping semver to ^7.5.4 (latest) in MetaMask/snaps and MetaMask/utils to ensure snap authors (and all other future imports) use version [built/signed with provenance](https://www.npmjs.com/package/semver?activeTab=versions) (new in >= 7.5.1) and fix [CVE-2022-25883](https://www.cve.org/CVERecord?id=CVE-2022-25883) (>= 7.5.2).

I spoke with @FrederikBolding yesterday, related PRs:
- MetaMask/snaps PR https://github.com/MetaMask/snaps/pull/1603
- MetaMask/snaps PR https://github.com/MetaMask/snaps/pull/1631
