### PR TITLE
Fix JsonRpcRequest to be valid json

### DIFF
--- a/src/json.ts
+++ b/src/json.ts
@@ -177,10 +177,10 @@ export type JsonRpcError = OptionalField<
   'data'
 >;
 
-export const JsonRpcParamsStruct = optional(
-  union([record(string(), JsonStruct), array(JsonStruct)]),
-);
-export type JsonRpcParams = Infer<typeof JsonRpcParamsStruct>;
+export const JsonRpcParamsStruct: Struct<Json[] | Record<string, Json>, null> =
+  optional(union([record(string(), JsonStruct), array(JsonStruct)])) as any;
+
+export type JsonRpcParams = Json[] | Record<string, Json>;
 
 export const JsonRpcRequestStruct = object({
   id: JsonRpcIdStruct,


### PR DESCRIPTION
fix/types: JsonRpcParams should be valid JSON values

`undefined` is not valid JSON.

https://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf (Section 5):

    A JSON value can be an object, array, number, string, true, false, or null.


Resolves: #129 

Related type error: https://github.com/MetaMask/providers/actions/runs/5959652471/job/16165741468?pr=275