### PR TITLE
Reduce type duplication by excluding `undefined`

### DIFF
--- a/src/json.ts
+++ b/src/json.ts
@@ -217,14 +217,9 @@ export const JsonRpcRequestStruct: Struct<
 export type InferWithParams<
   Type extends Struct<any>,
   Params extends JsonRpcParams,
-> = Omit<Infer<Type>, 'params'> &
-  (keyof Params extends undefined
-    ? {
-        params?: Params;
-      }
-    : {
-        params: Params;
-      });
+> = Omit<Infer<Type>, 'params'> & {
+  params?: Params;
+};
 
 /**
  * A JSON-RPC request object.

--- a/src/json.ts
+++ b/src/json.ts
@@ -198,7 +198,7 @@ export const JsonRpcRequestStruct: Struct<
   id: JsonRpcIdStruct,
   jsonrpc: JsonRpcVersionStruct,
   method: string(),
-  params: JsonRpcParamsStruct,
+  params: optional(JsonRpcParamsStruct),
 }) as Struct<
   {
     id: string | number | null;
@@ -246,7 +246,7 @@ export const JsonRpcNotificationStruct: Struct<
 > = object({
   jsonrpc: JsonRpcVersionStruct,
   method: string(),
-  params: JsonRpcParamsStruct,
+  params: optional(JsonRpcParamsStruct),
 }) as Struct<
   {
     jsonrpc: '2.0';

--- a/src/json.ts
+++ b/src/json.ts
@@ -181,44 +181,18 @@ export const JsonRpcParamsStruct: Struct<Json[] | Record<string, Json>, null> =
 
 export type JsonRpcParams = Json[] | Record<string, Json>;
 
-export const JsonRpcRequestStruct: Struct<
-  {
-    id: string | number | null;
-    jsonrpc: '2.0';
-    method: string;
-    params?: Json[] | Record<string, Json>;
-  },
-  {
-    id: Struct<string | number | null, null>;
-    jsonrpc: Struct<'2.0', '2.0'>;
-    method: Struct<string, null>;
-    params?: Struct<Json[] | Record<string, Json>, null>;
-  }
-> = object({
+export const JsonRpcRequestStruct = object({
   id: JsonRpcIdStruct,
   jsonrpc: JsonRpcVersionStruct,
   method: string(),
   params: optional(JsonRpcParamsStruct),
-}) as Struct<
-  {
-    id: string | number | null;
-    jsonrpc: '2.0';
-    method: string;
-    params?: Json[] | Record<string, Json>;
-  },
-  {
-    id: Struct<string | number | null, null>;
-    jsonrpc: Struct<'2.0', '2.0'>;
-    method: Struct<string, null>;
-    params?: Struct<Json[] | Record<string, Json>, null>;
-  }
->;
+});
 
 export type InferWithParams<
   Type extends Struct<any>,
   Params extends JsonRpcParams,
 > = Omit<Infer<Type>, 'params'> & {
-  params?: Params;
+  params?: Exclude<Params, undefined>;
 };
 
 /**
@@ -227,33 +201,11 @@ export type InferWithParams<
 export type JsonRpcRequest<Params extends JsonRpcParams = JsonRpcParams> =
   InferWithParams<typeof JsonRpcRequestStruct, Params>;
 
-export const JsonRpcNotificationStruct: Struct<
-  {
-    jsonrpc: '2.0';
-    method: string;
-    params?: Json[] | Record<string, Json>;
-  },
-  {
-    jsonrpc: Struct<'2.0', '2.0'>;
-    method: Struct<string, null>;
-    params?: Struct<Json[] | Record<string, Json>, null>;
-  }
-> = object({
+export const JsonRpcNotificationStruct = object({
   jsonrpc: JsonRpcVersionStruct,
   method: string(),
   params: optional(JsonRpcParamsStruct),
-}) as Struct<
-  {
-    jsonrpc: '2.0';
-    method: string;
-    params?: Json[] | Record<string, Json>;
-  },
-  {
-    jsonrpc: Struct<'2.0', '2.0'>;
-    method: Struct<string, null>;
-    params?: Struct<Json[] | Record<string, Json>, null>;
-  }
->;
+});
 
 /**
  * A JSON-RPC notification object.

--- a/src/json.ts
+++ b/src/json.ts
@@ -13,7 +13,6 @@ import {
   nullable,
   number,
   object,
-  omit,
   optional,
   record,
   string,
@@ -178,16 +177,42 @@ export type JsonRpcError = OptionalField<
 >;
 
 export const JsonRpcParamsStruct: Struct<Json[] | Record<string, Json>, null> =
-  optional(union([record(string(), JsonStruct), array(JsonStruct)])) as any;
+  union([record(string(), JsonStruct), array(JsonStruct)]);
 
 export type JsonRpcParams = Json[] | Record<string, Json>;
 
-export const JsonRpcRequestStruct = object({
+export const JsonRpcRequestStruct: Struct<
+  {
+    id: string | number | null;
+    jsonrpc: '2.0';
+    method: string;
+    params?: Json[] | Record<string, Json>;
+  },
+  {
+    id: Struct<string | number | null, null>;
+    jsonrpc: Struct<'2.0', '2.0'>;
+    method: Struct<string, null>;
+    params?: Struct<Json[] | Record<string, Json>, null>;
+  }
+> = object({
   id: JsonRpcIdStruct,
   jsonrpc: JsonRpcVersionStruct,
   method: string(),
   params: JsonRpcParamsStruct,
-});
+}) as Struct<
+  {
+    id: string | number | null;
+    jsonrpc: '2.0';
+    method: string;
+    params?: Json[] | Record<string, Json>;
+  },
+  {
+    id: Struct<string | number | null, null>;
+    jsonrpc: Struct<'2.0', '2.0'>;
+    method: Struct<string, null>;
+    params?: Struct<Json[] | Record<string, Json>, null>;
+  }
+>;
 
 export type InferWithParams<
   Type extends Struct<any>,
@@ -207,7 +232,33 @@ export type InferWithParams<
 export type JsonRpcRequest<Params extends JsonRpcParams = JsonRpcParams> =
   InferWithParams<typeof JsonRpcRequestStruct, Params>;
 
-export const JsonRpcNotificationStruct = omit(JsonRpcRequestStruct, ['id']);
+export const JsonRpcNotificationStruct: Struct<
+  {
+    jsonrpc: '2.0';
+    method: string;
+    params?: Json[] | Record<string, Json>;
+  },
+  {
+    jsonrpc: Struct<'2.0', '2.0'>;
+    method: Struct<string, null>;
+    params?: Struct<Json[] | Record<string, Json>, null>;
+  }
+> = object({
+  jsonrpc: JsonRpcVersionStruct,
+  method: string(),
+  params: JsonRpcParamsStruct,
+}) as Struct<
+  {
+    jsonrpc: '2.0';
+    method: string;
+    params?: Json[] | Record<string, Json>;
+  },
+  {
+    jsonrpc: Struct<'2.0', '2.0'>;
+    method: Struct<string, null>;
+    params?: Struct<Json[] | Record<string, Json>, null>;
+  }
+>;
 
 /**
  * A JSON-RPC notification object.


### PR DESCRIPTION
This is intended to be merged into @legobeat's branch (#134).