### PR TITLE
Fix issue with source maps

### DIFF
--- a/src/errors.test.ts
+++ b/src/errors.test.ts
@@ -175,6 +175,7 @@ describe('wrapError', () => {
           super(message);
           this.cause = options.cause;
         }
+
         cause: Error | undefined;
       }
       // Set length to 2

--- a/src/errors.test.ts
+++ b/src/errors.test.ts
@@ -182,6 +182,8 @@ describe('wrapError', () => {
       Object.defineProperty(MockError, 'length', { value: 2 });
 
       // Replace global Error with MockError
+      // NOTE: when we upgrade jest, change this to use:
+      // jest.replaceProperty(global, 'Error', MockError);
       global.Error = MockError as unknown as ErrorConstructor;
 
       // Define your original error and message

--- a/src/errors.test.ts
+++ b/src/errors.test.ts
@@ -164,6 +164,41 @@ describe('wrapError', () => {
     });
   });
 
+  describe('if the original error has a length === 2', () => {
+    it('returns an error with cause', () => {
+      // Save original Error
+      const OriginalError = global.Error;
+
+      // Create a mock error with a cause
+      class MockError extends Error {
+        constructor(message: string, options: { cause?: Error } = {}) {
+          super(message);
+          this.cause = options.cause;
+        }
+        cause: Error | undefined;
+      }
+      // Set length to 2
+      Object.defineProperty(MockError, 'length', { value: 2 });
+
+      // Replace global Error with MockError
+      global.Error = MockError as unknown as ErrorConstructor;
+
+      // Define your original error and message
+      const originalError = new Error('original error');
+      const message = 'new error message';
+
+      // Call your function
+      const result = wrapError(originalError, message);
+
+      // Assert that the error has the expected properties
+      expect(result.message).toBe(message);
+      expect(result.cause).toBe(originalError);
+
+      // Restore the original Error constructor
+      global.Error = OriginalError;
+    });
+  });
+
   describe('if the original error is an object but not an Error instance', () => {
     describe('if the message is a non-empty string', () => {
       it('combines a string version of the original error and message together in a new Error', () => {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -105,7 +105,7 @@ export function wrapError<Throwable>(
     } else {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
-      new ErrorWithCause(message, { cause: originalError });
+      error = new ErrorWithCause(message, { cause: originalError });
     }
 
     if (isErrorWithCode(originalError)) {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -101,7 +101,7 @@ export function wrapError<Throwable>(
     if (Error.length === 2) {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
-      error = new Error(message, { cause: originalError })
+      error = new Error(message, { cause: originalError });
     } else {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -95,7 +95,7 @@ export function wrapError<Throwable>(
     let error: Error & { code?: string };
     // This branch is getting tested by using the Node version that
     // supports `cause` on the Error constructor.
-    // istanbul ignore next 
+    // istanbul ignore next
     if (Error.length === 2) {
       // Also, for some reason `tsserver` is not complaining that the
       // Error constructor doesn't support a second argument in the editor,

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -92,19 +92,21 @@ export function wrapError<Throwable>(
   message: string,
 ): Error & { code?: string } {
   if (isError(originalError)) {
-    const error: Error & { code?: string } =
-      Error.length === 2
-        ? // This branch is getting tested by using the Node version that
-          // supports `cause` on the Error constructor.
-          // istanbul ignore next
-          // Also, for some reason `tsserver` is not complaining that the
-          // Error constructor doesn't support a second argument in the editor,
-          // but `tsc` does. I'm not sure why, but we disable this in the
-          // meantime.
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-ignore
-          new Error(message, { cause: originalError })
-        : new ErrorWithCause(message, { cause: originalError });
+    // This branch is getting tested by using the Node version that
+    // supports `cause` on the Error constructor.
+    // istanbul ignore next Also, for some reason `tsserver` is not complaining that the
+    // Error constructor doesn't support a second argument in the editor,
+    // but `tsc` does. Error causes are not supported by our current tsc target (ES2020, we need ES2022 to make this work)
+    let error: Error & { code?: string };
+    if (Error.length === 2) {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      error = new Error(message, { cause: originalError })
+    } else {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      new ErrorWithCause(message, { cause: originalError });
+    }
 
     if (isErrorWithCode(originalError)) {
       error.code = originalError.code;

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -92,13 +92,14 @@ export function wrapError<Throwable>(
   message: string,
 ): Error & { code?: string } {
   if (isError(originalError)) {
+    let error: Error & { code?: string };
     // This branch is getting tested by using the Node version that
     // supports `cause` on the Error constructor.
-    // istanbul ignore next Also, for some reason `tsserver` is not complaining that the
-    // Error constructor doesn't support a second argument in the editor,
-    // but `tsc` does. Error causes are not supported by our current tsc target (ES2020, we need ES2022 to make this work)
-    let error: Error & { code?: string };
+    // istanbul ignore next 
     if (Error.length === 2) {
+      // Also, for some reason `tsserver` is not complaining that the
+      // Error constructor doesn't support a second argument in the editor,
+      // but `tsc` does. Error causes are not supported by our current tsc target (ES2020, we need ES2022 to make this work)
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       error = new Error(message, { cause: originalError });

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -93,11 +93,8 @@ export function wrapError<Throwable>(
 ): Error & { code?: string } {
   if (isError(originalError)) {
     let error: Error & { code?: string };
-    // This branch is getting tested by using the Node version that
-    // supports `cause` on the Error constructor.
-    // istanbul ignore next
     if (Error.length === 2) {
-      // Also, for some reason `tsserver` is not complaining that the
+      // for some reason `tsserver` is not complaining that the
       // Error constructor doesn't support a second argument in the editor,
       // but `tsc` does. Error causes are not supported by our current tsc target (ES2020, we need ES2022 to make this work)
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/yarn.lock
+++ b/yarn.lock
@@ -1646,9 +1646,11 @@ __metadata:
   linkType: hard
 
 "@types/node@npm:*":
-  version: 18.7.23
-  resolution: "@types/node@npm:18.7.23"
-  checksum: 2c8df0830d8345e5cd1ca17feb9cf43fa667aae749888e0a068c5c1b35eaedd2f9b24ed987a0758078395edf7a03681e5e0b7790a518ff7afe1ff6d8459f7b4a
+  version: 20.9.0
+  resolution: "@types/node@npm:20.9.0"
+  dependencies:
+    undici-types: ~5.26.4
+  checksum: bfd927da6bff8a32051fa44bb47ca32a56d2c8bc8ba0170770f181cc1fa3c0b05863c9b930f0ba8604a48d5eb0d319166601709ca53bf2deae0025d8b6c6b8a3
   languageName: node
   linkType: hard
 
@@ -7604,6 +7606,13 @@ __metadata:
     has-symbols: ^1.0.3
     which-boxed-primitive: ^1.0.2
   checksum: b7a1cf5862b5e4b5deb091672ffa579aa274f648410009c81cca63fed3b62b610c4f3b773f912ce545bb4e31edc3138975b5bc777fc6e4817dca51affb6380e9
+  languageName: node
+  linkType: hard
+
+"undici-types@npm:~5.26.4":
+  version: 5.26.5
+  resolution: "undici-types@npm:5.26.5"
+  checksum: 3192ef6f3fd5df652f2dc1cd782b49d6ff14dc98e5dced492aa8a8c65425227da5da6aafe22523c67f035a272c599bb89cfe803c1db6311e44bed3042fc25487
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1646,11 +1646,9 @@ __metadata:
   linkType: hard
 
 "@types/node@npm:*":
-  version: 20.9.0
-  resolution: "@types/node@npm:20.9.0"
-  dependencies:
-    undici-types: ~5.26.4
-  checksum: bfd927da6bff8a32051fa44bb47ca32a56d2c8bc8ba0170770f181cc1fa3c0b05863c9b930f0ba8604a48d5eb0d319166601709ca53bf2deae0025d8b6c6b8a3
+  version: 18.7.23
+  resolution: "@types/node@npm:18.7.23"
+  checksum: 2c8df0830d8345e5cd1ca17feb9cf43fa667aae749888e0a068c5c1b35eaedd2f9b24ed987a0758078395edf7a03681e5e0b7790a518ff7afe1ff6d8459f7b4a
   languageName: node
   linkType: hard
 
@@ -7606,13 +7604,6 @@ __metadata:
     has-symbols: ^1.0.3
     which-boxed-primitive: ^1.0.2
   checksum: b7a1cf5862b5e4b5deb091672ffa579aa274f648410009c81cca63fed3b62b610c4f3b773f912ce545bb4e31edc3138975b5bc777fc6e4817dca51affb6380e9
-  languageName: node
-  linkType: hard
-
-"undici-types@npm:~5.26.4":
-  version: 5.26.5
-  resolution: "undici-types@npm:5.26.5"
-  checksum: 3192ef6f3fd5df652f2dc1cd782b49d6ff14dc98e5dced492aa8a8c65425227da5da6aafe22523c67f035a272c599bb89cfe803c1db6311e44bed3042fc25487
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->
The sourcemaps that are generated from the `error.ts` code are wrong. They seem to be having trouble with the `@ts-ignore` comment and some combination of the ternary statement. Unrolling the ternary into an if...else seems to resolve the issue, thoough a longer term fix would be to bump the tsconfig `target` field to `ES2022`  and remove the `@ts-ignore`

see https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/62187/workflows/98ccf0cb-168e-47d3-8d7e-b5e10edc129b/jobs/1964980 for more details