### PR TITLE
Assign unique name to sandbox directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     "debug": "^4.3.4",
     "pony-cause": "^2.1.10",
     "semver": "^7.5.4",
-    "superstruct": "^1.0.3"
+    "superstruct": "^1.0.3",
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^2.3.1",
@@ -72,6 +73,7 @@
     "@types/jest": "^28.1.7",
     "@types/jest-when": "^3.5.3",
     "@types/node": "^17.0.23",
+    "@types/uuid": "^9.0.8",
     "@typescript-eslint/eslint-plugin": "^5.43.0",
     "@typescript-eslint/parser": "^5.43.0",
     "depcheck": "^1.4.7",

--- a/src/fs.test.ts
+++ b/src/fs.test.ts
@@ -22,6 +22,8 @@ const { withinSandbox } = createSandbox('utils');
 // Clone the `uuid` module so that we can spy on its exports
 jest.mock('uuid', () => {
   return {
+    // This is how to mock an ES-compatible module in Jest.
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     __esModule: true,
     ...jest.requireActual('uuid'),
   };

--- a/src/fs.ts
+++ b/src/fs.ts
@@ -4,6 +4,7 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import * as uuid from 'uuid';
 
 import { isErrorWithCode, wrapError } from './errors';
 import type { Json } from './json';
@@ -240,8 +241,7 @@ export async function forceRemove(entryPath: string): Promise<void> {
  * ```
  */
 export function createSandbox(projectName: string): FileSandbox {
-  const timestamp = new Date().getTime();
-  const directoryPath = path.join(os.tmpdir(), `${projectName}--${timestamp}`);
+  const directoryPath = path.join(os.tmpdir(), projectName, uuid.v4());
 
   return {
     directoryPath,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1226,6 +1226,7 @@ __metadata:
     "@types/jest": ^28.1.7
     "@types/jest-when": ^3.5.3
     "@types/node": ^17.0.23
+    "@types/uuid": ^9.0.8
     "@typescript-eslint/eslint-plugin": ^5.43.0
     "@typescript-eslint/parser": ^5.43.0
     debug: ^4.3.4
@@ -1253,6 +1254,7 @@ __metadata:
     tsup: ^7.2.0
     typedoc: ^0.23.15
     typescript: ~4.8.4
+    uuid: ^9.0.1
   languageName: unknown
   linkType: soft
 
@@ -1691,6 +1693,13 @@ __metadata:
   version: 2.0.1
   resolution: "@types/stack-utils@npm:2.0.1"
   checksum: 205fdbe3326b7046d7eaf5e494d8084f2659086a266f3f9cf00bccc549c8e36e407f88168ad4383c8b07099957ad669f75f2532ed4bc70be2b037330f7bae019
+  languageName: node
+  linkType: hard
+
+"@types/uuid@npm:^9.0.8":
+  version: 9.0.8
+  resolution: "@types/uuid@npm:9.0.8"
+  checksum: b8c60b7ba8250356b5088302583d1704a4e1a13558d143c549c408bf8920535602ffc12394ede77f8a8083511b023704bc66d1345792714002bfa261b17c5275
   languageName: node
   linkType: hard
 
@@ -7670,6 +7679,15 @@ __metadata:
   version: 1.0.2
   resolution: "util-deprecate@npm:1.0.2"
   checksum: 474acf1146cb2701fe3b074892217553dfcf9a031280919ba1b8d651a068c9b15d863b7303cb15bd00a862b498e6cf4ad7b4a08fb134edd5a6f7641681cb54a2
+  languageName: node
+  linkType: hard
+
+"uuid@npm:^9.0.1":
+  version: 9.0.1
+  resolution: "uuid@npm:9.0.1"
+  bin:
+    uuid: dist/bin/uuid
+  checksum: 39931f6da74e307f51c0fb463dc2462807531dc80760a9bff1e35af4316131b4fc3203d16da60ae33f07fdca5b56f3f1dd662da0c99fea9aaeab2004780cc5f4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
`withinSandbox` is designed for tests that need to act on the filesystem. It creates a temporary directory and passes it to the function so that it can do whatever it needs to do within the directory in a safer fashion.

The name of the sandbox directory is generated from the current time to ensure that each one is unique. However, this causes problems when Jest is running more than one test file, each of which make use of the sandbox. Jest runs test files in parallel, so paired with the naming — and the fact that time can be frozen in tests — it is possible for two tests to create and use the same sandbox simultaneously. `withinSandbox` double-checks that the directory it would have created does not already exist, so when the first test creates the directory it will cause the second test to fail. Also, since `withinSandbox` removes the sandbox directory after it runs its function, this will also cause the second test to fail if it's still running and using that directory.

To fix this, this commit changes `withinSandbox` to use a UUID to name the sandbox directory instead of the current time.

---

Fixes #166.