### PR TITLE
Ensure functions that should return Hex, do

### DIFF
--- a/src/hex.ts
+++ b/src/hex.ts
@@ -87,7 +87,7 @@ export function isValidHexAddress(possibleAddress: Hex) {
  * @returns The address encoded according to ERC-55.
  * @see https://eips.ethereum.org/EIPS/eip-55
  */
-export function getChecksumAddress(address: Hex) {
+export function getChecksumAddress(address: Hex): Hex {
   assert(is(address, HexChecksumAddressStruct), 'Invalid hex address.');
   const unPrefixed = remove0x(address.toLowerCase());
   const unPrefixedHash = remove0x(bytesToHex(keccak256(unPrefixed)));

--- a/src/number.ts
+++ b/src/number.ts
@@ -1,4 +1,5 @@
 import { assert } from './assert';
+import type { Hex } from './hex';
 import { add0x, assertIsHexString } from './hex';
 
 /**
@@ -18,7 +19,7 @@ import { add0x, assertIsHexString } from './hex';
  * @returns The hexadecimal string, with the "0x"-prefix.
  * @throws If the number is not a non-negative safe integer.
  */
-export const numberToHex = (value: number): string => {
+export const numberToHex = (value: number): Hex => {
   assert(typeof value === 'number', 'Value must be a number.');
   assert(value >= 0, 'Value must be a non-negative number.');
   assert(
@@ -45,7 +46,7 @@ export const numberToHex = (value: number): string => {
  * @returns The hexadecimal string, with the "0x"-prefix.
  * @throws If the `bigint` is not a non-negative integer.
  */
-export const bigIntToHex = (value: bigint): string => {
+export const bigIntToHex = (value: bigint): Hex => {
   assert(typeof value === 'bigint', 'Value must be a bigint.');
   assert(value >= 0, 'Value must be a non-negative bigint.');
 


### PR DESCRIPTION
Some functions that return hex strings satisfying the `Hex` type return a `string` type instead. This makes it slightly inconvenient to use these functions in conjunction with others, and it is common in practice to use a type assertion as a workaround. This commit rectifies this issue by assigning these functions proper return types:

- `getChecksumAddress`
- `numberToHex`
- `bigIntToHex`

As such this change is **breaking**.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

Fixes #159.
