### PR TITLE
feat: Add PublicInterface type

### DIFF
--- a/src/misc.test-d.ts
+++ b/src/misc.test-d.ts
@@ -1,7 +1,27 @@
 import { expectAssignable, expectNotAssignable, expectType } from 'tsd';
 
-import type { RuntimeObject } from './misc';
+import type { PublicInterface, RuntimeObject } from './misc';
 import { isObject, hasProperty, getKnownPropertyNames } from './misc';
+
+//=============================================================================
+// PublicInterface
+//=============================================================================
+
+class ClassWithPrivateProperties {
+  #foo: string;
+
+  bar: string;
+
+  constructor({ foo, bar }: { foo: string; bar: string }) {
+    this.#foo = foo;
+    this.bar = bar;
+  }
+}
+
+// Private properties not required
+expectAssignable<PublicInterface<ClassWithPrivateProperties>>({ bar: 'bar' });
+// Public properties still required
+expectNotAssignable<PublicInterface<ClassWithPrivateProperties>>({});
 
 //=============================================================================
 // isObject

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -18,6 +18,15 @@ export type Mutable<
 };
 
 /**
+ * Get a type representing the public interface of the given type. The
+ * returned type will have all public properties, but will omit private
+ * properties.
+ *
+ * @template Interface - The interface to return a public representation of.
+ */
+export type PublicInterface<Interface> = Pick<Interface, keyof Interface>;
+
+/**
  * Useful for representing some value that _might_ be present and / or complete.
  *
  * @template Value - The value that might be present or complete.


### PR DESCRIPTION
Add a type for deriving the "public interface" of a type, excluding private properties. Excluding private properties can be useful in making our classes more easily testable (types with private properties are more difficult to mock).

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->
