### PR TITLE
Add Wallet member to KnownCaipNamespace enum

### DIFF
--- a/src/caip-types.ts
+++ b/src/caip-types.ts
@@ -50,6 +50,7 @@ export type CaipAccountAddress = Infer<typeof CaipAccountAddressStruct>;
 export enum KnownCaipNamespace {
   /** EIP-155 compatible chains. */
   Eip155 = 'eip155',
+  Wallet = 'wallet',
 }
 
 /**


### PR DESCRIPTION
Add `Wallet` member to `KnownCaipNamespace` enum. This is needed for supporting [CAIP-25 and CAIP-27 Multichain requests in Extension](https://github.com/MetaMask/metamask-extension/pull/25665)
