### PR TITLE
feat: add `KnownCaipNamespace.Bip122` for Bitcoin family

### DIFF
--- a/src/caip-types.test.ts
+++ b/src/caip-types.test.ts
@@ -295,10 +295,7 @@ describe('toCaipChainId', () => {
   it.each(Object.values(KnownCaipNamespace))(
     'treats %s as a valid namespace',
     (namespace) => {
-      const reference = '1';
-      expect(toCaipChainId(namespace, reference)).toBe(
-        `${namespace}:${reference}`,
-      );
+      expect(isCaipNamespace(namespace)).toBe(true);
     },
   );
 

--- a/src/caip-types.ts
+++ b/src/caip-types.ts
@@ -54,6 +54,8 @@ export type CaipAccountAddress = Infer<typeof CaipAccountAddressStruct>;
 
 /** Known CAIP namespaces. */
 export enum KnownCaipNamespace {
+  /** BIP-122 (Bitcoin) compatible chains. */
+  Bip122 = 'bip122',
   /** EIP-155 compatible chains. */
   Eip155 = 'eip155',
   Wallet = 'wallet',


### PR DESCRIPTION
Adding a new known CAIP namespace for Bitcoin.

You can find a proper BIP-122 CAIP 2 identifier here:
- https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-2.md#test-cases

We could also update the for `KnownCaipNamespaces` to match those test cases but the test as-is seems good enough AND future-proof too. 