### PR TITLE
chore: add Solana CAIP namespace

### DIFF
--- a/src/caip-types.ts
+++ b/src/caip-types.ts
@@ -80,6 +80,8 @@ export type CaipAssetId = `${string}:${string}/${string}:${string}/${string}`;
 export enum KnownCaipNamespace {
   /** BIP-122 (Bitcoin) compatible chains. */
   Bip122 = 'bip122',
+  /** Solana compatible chains */
+  Solana = 'solana',
   /** EIP-155 compatible chains. */
   Eip155 = 'eip155',
   Wallet = 'wallet',


### PR DESCRIPTION
* What is the current state of things and why does it need to change?

We have a list of namespaces that includes EVM and Bitcoin chains. We are missing Solana chains.

* What is the solution your changes offer and how does it work?

I have added the Solana CAIP namespace as per: https://namespaces.chainagnostic.org/solana/caip2