### PR TITLE
Improve error message for invalid JSON values

### DIFF
--- a/src/json.test.ts
+++ b/src/json.test.ts
@@ -239,6 +239,18 @@ describe('json', () => {
         'Expected a value of type `JSON`, but received: `undefined`',
       );
     });
+
+    it('returns a readable error message for a nested JsonStruct', () => {
+      const struct = object({
+        value: JsonStruct,
+      });
+
+      const [error] = validate({ value: undefined }, struct);
+      assert(error !== undefined);
+      expect(error.message).toBe(
+        'At path: value -- Expected a value of type `JSON`, but received: `undefined`',
+      );
+    });
   });
 
   describe('getSafeJson', () => {

--- a/src/json.ts
+++ b/src/json.ts
@@ -16,7 +16,6 @@ import {
   union,
   unknown,
   Struct,
-  assert,
   refine,
 } from '@metamask/superstruct';
 import type {

--- a/src/json.ts
+++ b/src/json.ts
@@ -16,6 +16,8 @@ import {
   union,
   unknown,
   Struct,
+  assert,
+  refine,
 } from '@metamask/superstruct';
 import type {
   Context,
@@ -215,18 +217,20 @@ export const UnsafeJsonStruct: Struct<Json> = define('JSON', (json) =>
  * This struct sanitizes the value before validating it, so that it is safe to
  * use with untrusted input.
  */
-export const JsonStruct = coerce(UnsafeJsonStruct, any(), (value) => {
-  assertStruct(value, UnsafeJsonStruct);
-  return JSON.parse(
-    JSON.stringify(value, (propKey, propValue) => {
-      // Strip __proto__ and constructor properties to prevent prototype pollution.
-      if (propKey === '__proto__' || propKey === 'constructor') {
-        return undefined;
-      }
-      return propValue;
-    }),
-  );
-});
+export const JsonStruct = coerce(
+  UnsafeJsonStruct,
+  refine(any(), 'JSON', (value) => is(value, UnsafeJsonStruct)),
+  (value) =>
+    JSON.parse(
+      JSON.stringify(value, (propKey, propValue) => {
+        // Strip __proto__ and constructor properties to prevent prototype pollution.
+        if (propKey === '__proto__' || propKey === 'constructor') {
+          return undefined;
+        }
+        return propValue;
+      }),
+    ),
+);
 
 /**
  * Check if the given value is a valid {@link Json} value, i.e., a value that is


### PR DESCRIPTION
Currently we use `assertStruct` in the `JsonStruct`, to ensure that the value is JSON-serialisable before coercing it. `assertStruct` returns a generic `AssertionError`, and Superstruct doesn't have any information about where the error was thrown (such as the path). Given the following struct for example:

```ts
const ExampleStruct = object({
  value: JsonStruct,
});
```

An invalid `value` would result in an `AssertionError` with the following message:

> Assertion failed: Expected a value of type `JSON`, but received: `undefined`.

After this change, a `StructError` is thrown instead, with the following message:

> At path: value -- Expected a value of type `JSON`, but received: `undefined`.

This makes it more clear that the error happens at `value`, and it also makes more sense to throw a `StructError` in this case.