### PR TITLE
feat: add optional `signEip7702Authorization` method to `Keyring` type

### DIFF
--- a/src/keyring.ts
+++ b/src/keyring.ts
@@ -11,7 +11,7 @@ import type { Json } from './json';
  * static property on Keyring classes. See the {@link Keyring} type for more
  * information.
  */
-export type KeyringClass = {
+export type KeyringClass<State extends Json> = {
   /**
    * The Keyring constructor. Takes a single parameter, an "options" object.
    * See the documentation for the specific keyring for more information about
@@ -20,7 +20,7 @@ export type KeyringClass = {
    * @param options - The constructor options. Differs between keyring
    * implementations.
    */
-  new (options?: Record<string, unknown>): Keyring;
+  new (options?: Record<string, unknown>): Keyring<State>;
 
   /**
    * The name of this type of keyring. This must uniquely identify the
@@ -44,7 +44,7 @@ export type KeyringClass = {
  * should be treated with care though, just in case it does contain sensitive
  * material such as a private key.
  */
-export type Keyring = {
+export type Keyring<State extends Json> = {
   /**
    * The name of this type of keyring. This must match the `type` property of
    * the keyring class.
@@ -71,7 +71,7 @@ export type Keyring = {
    *
    * @returns A JSON-serializable representation of the keyring state.
    */
-  serialize(): Promise<Json>;
+  serialize(): Promise<State>;
 
   /**
    * Deserialize the given keyring state, overwriting any existing state with
@@ -79,7 +79,7 @@ export type Keyring = {
    *
    * @param state - A JSON-serializable representation of the keyring state.
    */
-  deserialize(state: Json): Promise<void>;
+  deserialize(state: State): Promise<void>;
 
   /**
    * Method to include asynchronous configuration.

--- a/src/keyring.ts
+++ b/src/keyring.ts
@@ -179,7 +179,7 @@ export type Keyring<State extends Json> = {
    * @param options - Signing options; differs between keyrings.
    * @returns The signed authorization as a hex string.
    */
-  signEIP7702Authorization?(
+  signEip7702Authorization?(
     address: Hex,
     authorization: [chainId: number, contractAddress: Hex, nonce: number],
     options?: Record<string, unknown>,

--- a/src/keyring.ts
+++ b/src/keyring.ts
@@ -170,6 +170,22 @@ export type Keyring<State extends Json> = {
   ): Promise<string>;
 
   /**
+   * Sign an EIP-7702 authorization. This is a signing method for authorizing a
+   * specific contract on a specific chain.
+   *
+   * @param address - The address of the account to use for signing.
+   * @param authorization - An array containing the chain ID, contract address,
+   * and nonce.
+   * @param options - Signing options; differs between keyrings.
+   * @returns The signed authorization as a hex string.
+   */
+  signEIP7702Authorization?(
+    address: Hex,
+    authorization: [chainId: number, contractAddress: Hex, nonce: number],
+    options?: Record<string, unknown>,
+  ): Promise<string>;
+
+  /**
    * Sign a message. This is equivalent to the `eth_sign` Ethereum JSON-RPC
    * method, which is exposed by MetaMask as the method `personal_sign`. See
    * the Ethereum JSON-RPC API documentation for more details.


### PR DESCRIPTION
EIP-7702 defines a new struct Authorization which represents authority to set a pointer to a contract address at an EOA - effectively making the EOA perform as a smart contract.

This change adds an optional `signEip7702Authorization` method to the `Keyring` type which is implemented on `@metamask/eth-simple-keyring` and `@metamask/eth-hd-keyring` in https://github.com/MetaMask/accounts/pull/182.

See https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7702.md for details