### PR TITLE
fix!: `Keyring.serialize` and `Keyring.deserialize` types

### DIFF
--- a/src/keyring.ts
+++ b/src/keyring.ts
@@ -11,7 +11,7 @@ import type { Json } from './json';
  * static property on Keyring classes. See the {@link Keyring} type for more
  * information.
  */
-export type KeyringClass<State extends Json> = {
+export type KeyringClass = {
   /**
    * The Keyring constructor. Takes a single parameter, an "options" object.
    * See the documentation for the specific keyring for more information about
@@ -20,7 +20,7 @@ export type KeyringClass<State extends Json> = {
    * @param options - The constructor options. Differs between keyring
    * implementations.
    */
-  new (options?: Record<string, unknown>): Keyring<State>;
+  new (options?: Record<string, unknown>): Keyring;
 
   /**
    * The name of this type of keyring. This must uniquely identify the
@@ -44,7 +44,7 @@ export type KeyringClass<State extends Json> = {
  * should be treated with care though, just in case it does contain sensitive
  * material such as a private key.
  */
-export type Keyring<State extends Json> = {
+export type Keyring = {
   /**
    * The name of this type of keyring. This must match the `type` property of
    * the keyring class.
@@ -71,7 +71,7 @@ export type Keyring<State extends Json> = {
    *
    * @returns A JSON-serializable representation of the keyring state.
    */
-  serialize(): Promise<State>;
+  serialize(): Promise<Json>;
 
   /**
    * Deserialize the given keyring state, overwriting any existing state with
@@ -79,7 +79,7 @@ export type Keyring<State extends Json> = {
    *
    * @param state - A JSON-serializable representation of the keyring state.
    */
-  deserialize(state: State): Promise<void>;
+  deserialize(state: Json): Promise<void>;
 
   /**
    * Method to include asynchronous configuration.


### PR DESCRIPTION
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->
The `deserialize` and `serialize` methods present wrong signatures as they expect the `State extends Json` generic type passed to the `Keyring` for their arguments and return value. 

They now present the following signatures:
- `serialize(): Promise<Json>`
- `deserialize(state: Json): Promise<void>`

Since now the `State extends Json` generic is unused, it has been removed from the `Keyring` type

* Fixes: #128 
