### PR TITLE
Revert "12.0.0 (#233)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [12.0.0]
-### Changed
-- **BREAKING:** The `State` generic has been removed from the `KeyringClass` and `Keyring` types ([#232](https://github.com/MetaMask/utils/pull/232))
-  - The `serialize` method of the `Keyring` type now returns a `Promise<Json>`
-  - The `deserialize` method of the `Keyring` type now accepts `Json` as its argument
-
 ## [11.1.0]
 ### Added
 - Add additional CAIP-19 types (`CaipAsset{Namespace,Reference,TokenId}` support ([#227](https://github.com/MetaMask/utils/pull/227))
@@ -298,8 +292,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release
 
-[Unreleased]: https://github.com/MetaMask/utils/compare/v12.0.0...HEAD
-[12.0.0]: https://github.com/MetaMask/utils/compare/v11.1.0...v12.0.0
+[Unreleased]: https://github.com/MetaMask/utils/compare/v11.1.0...HEAD
 [11.1.0]: https://github.com/MetaMask/utils/compare/v11.0.1...v11.1.0
 [11.0.1]: https://github.com/MetaMask/utils/compare/v11.0.0...v11.0.1
 [11.0.0]: https://github.com/MetaMask/utils/compare/v10.0.1...v11.0.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/utils",
-  "version": "12.0.0",
+  "version": "11.1.0",
   "description": "Various JavaScript/TypeScript utilities of wide relevance to the MetaMask codebase",
   "homepage": "https://github.com/MetaMask/utils#readme",
   "bugs": {


### PR DESCRIPTION
This PR reverts the 12.0.0 release at commit a869df23f75f5ec83789a315c9828a3578c4348c. The reason is we decided to move the `Keyring` type away from this package.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->
