### PR TITLE
Fix API docs generation

### DIFF
--- a/typedoc.json
+++ b/typedoc.json
@@ -2,5 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs"
+  "out": "docs",
+  "tsconfig": "tsconfig.build.json"
 }


### PR DESCRIPTION
The addition of `web3` as a development dependency in 0a6e1bd7eb1b8c6e71d11945dd8c637743f93ecf broke `yarn build:docs`, which generates API docs via TypeDoc and is run when a new version of the package is published. Curiously, `yarn build` continues to work.

It seems that TypeDoc is using the development variant of the TypeScript configuration file instead of the build variant, which `yarn build` uses internally. The build variant limits the scope of TypeScript to just files within `src`, hiding dependencies. Correcting the TypeDoc config to use this file fixes the issue.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

## References

Fixes #263.

## Manual testing steps

- Run `yarn build:docs`. You should not see any type errors.