### PR TITLE
chore: replace calls of the slow superstruct "is" with faster regex

### DIFF
--- a/src/caip-types.ts
+++ b/src/caip-types.ts
@@ -1,5 +1,4 @@
 import type { Infer } from '@metamask/superstruct';
-import { is } from '@metamask/superstruct';
 
 import { definePattern } from './superstruct';
 
@@ -164,7 +163,7 @@ export type KnownCaipNamespacedChainId<
  * @returns Whether the value is a {@link CaipChainId}.
  */
 export function isCaipChainId(value: unknown): value is CaipChainId {
-  return is(value, CaipChainIdStruct);
+  return typeof value === 'string' && CAIP_CHAIN_ID_REGEX.test(value);
 }
 
 /**
@@ -174,7 +173,7 @@ export function isCaipChainId(value: unknown): value is CaipChainId {
  * @returns Whether the value is a {@link CaipNamespace}.
  */
 export function isCaipNamespace(value: unknown): value is CaipNamespace {
-  return is(value, CaipNamespaceStruct);
+  return typeof value === 'string' && CAIP_NAMESPACE_REGEX.test(value);
 }
 
 /**
@@ -184,7 +183,7 @@ export function isCaipNamespace(value: unknown): value is CaipNamespace {
  * @returns Whether the value is a {@link CaipReference}.
  */
 export function isCaipReference(value: unknown): value is CaipReference {
-  return is(value, CaipReferenceStruct);
+  return typeof value === 'string' && CAIP_REFERENCE_REGEX.test(value);
 }
 
 /**
@@ -194,7 +193,7 @@ export function isCaipReference(value: unknown): value is CaipReference {
  * @returns Whether the value is a {@link CaipAccountId}.
  */
 export function isCaipAccountId(value: unknown): value is CaipAccountId {
-  return is(value, CaipAccountIdStruct);
+  return typeof value === 'string' && CAIP_ACCOUNT_ID_REGEX.test(value);
 }
 
 /**
@@ -206,7 +205,7 @@ export function isCaipAccountId(value: unknown): value is CaipAccountId {
 export function isCaipAccountAddress(
   value: unknown,
 ): value is CaipAccountAddress {
-  return is(value, CaipAccountAddressStruct);
+  return typeof value === 'string' && CAIP_ACCOUNT_ADDRESS_REGEX.test(value);
 }
 
 /**
@@ -218,7 +217,7 @@ export function isCaipAccountAddress(
 export function isCaipAssetNamespace(
   value: unknown,
 ): value is CaipAssetNamespace {
-  return is(value, CaipAssetNamespaceStruct);
+  return typeof value === 'string' && CAIP_ASSET_NAMESPACE_REGEX.test(value);
 }
 
 /**
@@ -230,7 +229,7 @@ export function isCaipAssetNamespace(
 export function isCaipAssetReference(
   value: unknown,
 ): value is CaipAssetReference {
-  return is(value, CaipAssetReferenceStruct);
+  return typeof value === 'string' && CAIP_ASSET_REFERENCE_REGEX.test(value);
 }
 
 /**
@@ -240,7 +239,7 @@ export function isCaipAssetReference(
  * @returns Whether the value is a {@link CaipTokenId}.
  */
 export function isCaipTokenId(value: unknown): value is CaipTokenId {
-  return is(value, CaipTokenIdStruct);
+  return typeof value === 'string' && CAIP_TOKEN_ID_REGEX.test(value);
 }
 
 /**
@@ -250,7 +249,7 @@ export function isCaipTokenId(value: unknown): value is CaipTokenId {
  * @returns Whether the value is a {@link CaipAssetType}.
  */
 export function isCaipAssetType(value: unknown): value is CaipAssetType {
-  return is(value, CaipAssetTypeStruct);
+  return typeof value === 'string' && CAIP_ASSET_TYPE_REGEX.test(value);
 }
 
 /**
@@ -260,7 +259,7 @@ export function isCaipAssetType(value: unknown): value is CaipAssetType {
  * @returns Whether the value is a {@link CaipAssetId}.
  */
 export function isCaipAssetId(value: unknown): value is CaipAssetId {
-  return is(value, CaipAssetIdStruct);
+  return typeof value === 'string' && CAIP_ASSET_ID_REGEX.test(value);
 }
 
 /**


### PR DESCRIPTION
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->
The current use of the `is` function from the `superstruct` package is drastically slowing down caip type checks. This replaces those function calls with much faster regex checks.