### PR TITLE
Ban enums, and replace them with alternatives

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,6 +7,16 @@ module.exports = {
     {
       files: ['*.ts'],
       extends: ['@metamask/eslint-config-typescript'],
+      rules: {
+        'no-restricted-syntax': [
+          'error',
+          {
+            selector: 'TSEnumDeclaration',
+            message:
+              "Don't use enums. There are a number of reasons why they are problematic, but the most important is that TypeScript treats them nominally, not structurally, and this can cause unexpected breaking changes. Instead, use an object + type, an array + type, or just a type. Learn more here: https://github.com/MetaMask/eslint-config/issues/417",
+          },
+        ],
+      },
     },
 
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING:** Change `KnownCaipNamespace`, `JsonSize`, and `Duration` from enums to object literals + object types
+  - If you are accessing a member of these enums at runtime (e.g. `KnownCaipNamespace.Eip155`), you should not have to change anything, nor should you have any breaking changes.
+  - If you are using the whole enum type within another type or within a function or method signature (e.g. `function resolveRpcMethod(namespace: KnownCaipNamespace) { ... }`), these changes will be breaking for you. Consumers of your library will need to switch to `@metamask/utils` 12.0.0.
+  - Accessing a member of the enum type at compile time as though it were an object (e.g. `function resolveRpcMethod(namespace: KnownCaipNamespace.Eip155) { ... }`) is no longer supported. Use a literal (e.g. `'Eip155'`) instead.
+
 ## [11.11.0]
 
 ### Added

--- a/src/caip-types.ts
+++ b/src/caip-types.ts
@@ -131,19 +131,22 @@ export const CaipAssetTypeOrIdStruct = definePattern<
 export type CaipAssetTypeOrId = Infer<typeof CaipAssetTypeOrIdStruct>;
 
 /** Known CAIP namespaces. */
-export enum KnownCaipNamespace {
+export const KnownCaipNamespace = {
   /** BIP-122 (Bitcoin) compatible chains. */
-  Bip122 = 'bip122',
+  Bip122: 'bip122',
   /** Solana compatible chains */
-  Solana = 'solana',
+  Solana: 'solana',
   /** Stellar compatible chains */
-  Stellar = 'stellar',
+  Stellar: 'stellar',
   /** Tron compatible chains */
-  Tron = 'tron',
+  Tron: 'tron',
   /** EIP-155 compatible chains. */
-  Eip155 = 'eip155',
-  Wallet = 'wallet',
-}
+  Eip155: 'eip155',
+  Wallet: 'wallet',
+} as const;
+
+export type KnownCaipNamespace =
+  (typeof KnownCaipNamespace)[keyof typeof KnownCaipNamespace];
 
 /**
  * A CAIP-2 chain ID that is guaranteed to have a known CAIP namespace

--- a/src/misc.test-d.ts
+++ b/src/misc.test-d.ts
@@ -124,13 +124,13 @@ if (hasProperty(hasPropertyTypeExample, 'a')) {
 // getKnownPropertyNames
 //=============================================================================
 
-enum GetKnownPropertyNamesEnumExample {
-  Foo = 'bar',
-  Baz = 'qux',
-}
+const GetKnownPropertyNamesExample = {
+  Foo: 'bar',
+  Baz: 'qux',
+} as const;
 
 expectType<('Foo' | 'Baz')[]>(
-  getKnownPropertyNames(GetKnownPropertyNamesEnumExample),
+  getKnownPropertyNames(GetKnownPropertyNamesExample),
 );
 
 //=============================================================================

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -130,17 +130,18 @@ export type PlainObject = Record<number | string | symbol, unknown>;
 /**
  * Predefined sizes (in Bytes) of specific parts of JSON structure.
  */
-export enum JsonSize {
-  Null = 4,
-  Comma = 1,
-  Wrapper = 1,
-  True = 4,
-  False = 5,
-  Quote = 1,
-  Colon = 1,
-  // eslint-disable-next-line @typescript-eslint/no-shadow
-  Date = 24,
-}
+export const JsonSize = {
+  Null: 4,
+  Comma: 1,
+  Wrapper: 1,
+  True: 4,
+  False: 5,
+  Quote: 1,
+  Colon: 1,
+  Date: 24,
+} as const;
+
+export type JsonSize = (typeof JsonSize)[keyof typeof JsonSize];
 
 /**
  * Regular expression with pattern matching for (special) escaped characters.

--- a/src/time.test.ts
+++ b/src/time.test.ts
@@ -30,9 +30,7 @@ describe('time utilities', () => {
 
       Object.values(Duration).forEach((duration) => {
         const count = getRandomCount();
-        expect(inMilliseconds(count, duration as Duration)).toBe(
-          count * (duration as Duration),
-        );
+        expect(inMilliseconds(count, duration)).toBe(count * duration);
       });
     });
   });

--- a/src/time.ts
+++ b/src/time.ts
@@ -1,42 +1,44 @@
 /**
  * Common duration constants, in milliseconds.
  */
-export enum Duration {
+export const Duration = {
   /**
    * A millisecond.
    */
-  Millisecond = 1,
+  Millisecond: 1,
 
   /**
    * A second, in milliseconds.
    */
-  Second = 1000, // Millisecond * 1000
+  Second: 1000, // Millisecond * 1000
 
   /**
    * A minute, in milliseconds.
    */
-  Minute = 60_000, // Second * 60
+  Minute: 60_000, // Second * 60
 
   /**
    * An hour, in milliseconds.
    */
-  Hour = 3_600_000, // Minute * 60
+  Hour: 3_600_000, // Minute * 60
 
   /**
    * A day, in milliseconds.
    */
-  Day = 86_400_000, // Hour * 24
+  Day: 86_400_000, // Hour * 24
 
   /**
    * A week, in milliseconds.
    */
-  Week = 604_800_000, // Day * 7
+  Week: 604_800_000, // Day * 7
 
   /**
    * A year, in milliseconds.
    */
-  Year = 31_536_000_000, // Day * 365
-}
+  Year: 31_536_000_000, // Day * 365
+} as const;
+
+export type Duration = (typeof Duration)[keyof typeof Duration];
 
 const isNonNegativeInteger = (number: number) =>
   Number.isInteger(number) && number >= 0;


### PR DESCRIPTION
There are a number of reasons why enums are bad, but the biggest problem — the one that affects us most — is that enums behave differently than the rest of TypeScript: while TypeScript is usually a **structural type system**, enums break the mold and are treated as **nominal types**.

This creates unintentional type errors. For instance, if one package has a function which takes an argument of type `KnownCaipNamespace` from `@metamask/utils` 11.1.0, and another package attempts to call that function with a member of `KnownCaipNamespace` from `@metamask/utils` 11.0.0, then a type error would be produced, even if the enums across both versions have the same exact contents. The second package would need to bump to 11.1.0 to fix the error.

There are other strange and undesirable "features" of enums that we do use. These are detailed here:
https://github.com/MetaMask/eslint-config/issues/417

To prevent these kinds of problems from occurring in the future, this commit adds a lint rule to ban the use of enums, and updates all instances of enums to use object literals and types instead.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces breaking type changes to exported constants that may require downstream TypeScript updates, though runtime access patterns like `Duration.Second` should remain compatible.
> 
> **Overview**
> This PR **bans TypeScript `enum` usage** via an ESLint `no-restricted-syntax` rule for `TSEnumDeclaration` to prevent future enum additions.
> 
> It replaces the exported enums `KnownCaipNamespace`, `JsonSize`, and `Duration` with `as const` object literals plus derived union types, and updates the type tests/usages accordingly (e.g., `Object.values(Duration)` now yields typed numeric values). The changelog is updated to call out the **breaking** type-level impact for consumers relying on the enum types in signatures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1126244aec719595c52854880e661f0bbb66665. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->