### PR TITLE
chore: remove `uuid` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,8 +71,7 @@
     "debug": "^4.3.4",
     "lodash": "^4.17.21",
     "pony-cause": "^2.1.10",
-    "semver": "^7.5.4",
-    "uuid": "^9.0.1"
+    "semver": "^7.5.4"
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^3.0.4",
@@ -87,7 +86,6 @@
     "@types/jest": "^28.1.7",
     "@types/jest-when": "^3.5.3",
     "@types/node": "~18.18.14",
-    "@types/uuid": "^9.0.8",
     "@typescript-eslint/eslint-plugin": "^5.43.0",
     "@typescript-eslint/parser": "^5.43.0",
     "depcheck": "^1.4.7",

--- a/src/fs.test.ts
+++ b/src/fs.test.ts
@@ -1,9 +1,9 @@
+import crypto from 'crypto';
 import fs from 'fs';
 import { when } from 'jest-when';
 import os from 'os';
 import path from 'path';
 import util from 'util';
-import * as uuid from 'uuid';
 
 import {
   createSandbox,
@@ -19,13 +19,13 @@ import {
 
 const { withinSandbox } = createSandbox('utils');
 
-// Clone the `uuid` module so that we can spy on its exports
-jest.mock('uuid', () => {
+// Clone the `crypto` module so that we can spy on its exports
+jest.mock('crypto', () => {
   return {
     // This is how to mock an ES-compatible module in Jest.
     // eslint-disable-next-line @typescript-eslint/naming-convention
     __esModule: true,
-    ...jest.requireActual('uuid'),
+    ...jest.requireActual('crypto'),
   };
 });
 
@@ -685,7 +685,7 @@ describe('fs', () => {
     });
 
     it('does not create the sandbox directory immediately', async () => {
-      jest.spyOn(uuid, 'v4').mockReturnValue('AAAA-AAAA-AAAA-AAAA');
+      jest.spyOn(crypto, 'randomUUID').mockReturnValue('AAAA-AAAA-AAAA-AAAA');
       createSandbox('utils-fs');
 
       const sandboxDirectoryPath = path.join(
@@ -702,7 +702,7 @@ describe('fs', () => {
     describe('withinSandbox', () => {
       it('creates the sandbox directory and keeps it around before its given function ends', async () => {
         expect.assertions(1);
-        jest.spyOn(uuid, 'v4').mockReturnValue('AAAA-AAAA-AAAA-AAAA');
+        jest.spyOn(crypto, 'randomUUID').mockReturnValue('AAAA-AAAA-AAAA-AAAA');
         const { withinSandbox: withinTestSandbox } = createSandbox('utils-fs');
 
         await withinTestSandbox(async () => {
@@ -718,7 +718,7 @@ describe('fs', () => {
       });
 
       it('removes the sandbox directory after its given function ends', async () => {
-        jest.spyOn(uuid, 'v4').mockReturnValue('AAAA-AAAA-AAAA-AAAA');
+        jest.spyOn(crypto, 'randomUUID').mockReturnValue('AAAA-AAAA-AAAA-AAAA');
         const { withinSandbox: withinTestSandbox } = createSandbox('utils-fs');
 
         await withinTestSandbox(async () => {
@@ -736,7 +736,7 @@ describe('fs', () => {
       });
 
       it('throws if the sandbox directory already exists', async () => {
-        jest.spyOn(uuid, 'v4').mockReturnValue('AAAA-AAAA-AAAA-AAAA');
+        jest.spyOn(crypto, 'randomUUID').mockReturnValue('AAAA-AAAA-AAAA-AAAA');
         const { withinSandbox: withinTestSandbox } = createSandbox('utils-fs');
 
         const sandboxDirectoryPath = path.join(

--- a/src/fs.test.ts
+++ b/src/fs.test.ts
@@ -1,4 +1,4 @@
-import crypto from 'crypto';
+import * as crypto from 'crypto';
 import fs from 'fs';
 import { when } from 'jest-when';
 import os from 'os';

--- a/src/fs.ts
+++ b/src/fs.ts
@@ -4,7 +4,7 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import * as uuid from 'uuid';
+import * as crypto from 'crypto';
 
 import { isErrorWithCode, wrapError } from './errors';
 import type { Json } from './json';
@@ -241,7 +241,7 @@ export async function forceRemove(entryPath: string): Promise<void> {
  * ```
  */
 export function createSandbox(projectName: string): FileSandbox {
-  const directoryPath = path.join(os.tmpdir(), projectName, uuid.v4());
+  const directoryPath = path.join(os.tmpdir(), projectName, crypto.randomUUID());
 
   return {
     directoryPath,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small dependency swap in test-only sandbox naming; supported by the package’s Node engine range (^18.18+).
> 
> **Overview**
> Drops the **`uuid`** package (and **`@types/uuid`**) and uses Node’s built-in **`crypto.randomUUID()`** for temporary test sandbox directory names in **`createSandbox`** (`src/fs.ts`).
> 
> **`fs.test.ts`** mocks **`crypto.randomUUID`** instead of **`uuid.v4`** so sandbox path behavior stays deterministic in tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0322fcabc1311965cb0da5c924551ad5c2559eb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->