### PR TITLE
ci: Update `action-npm-publish` to v6

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,6 +86,7 @@ jobs:
     name: Publish release
     permissions:
       contents: write
+      id-token: write
     uses: ./.github/workflows/publish-release.yml
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     secrets:
       NPM_TOKEN:
-        required: true
+        required: false
       SLACK_WEBHOOK_URL:
         required: true
       PUBLISH_DOCS_TOKEN:
@@ -49,8 +49,7 @@ jobs:
         with:
           name: publish-release-artifacts-${{ github.sha }}
       - name: Dry Run Publish
-        # omit npm-token token to perform dry run publish
-        uses: MetaMask/action-npm-publish@v5
+        uses: MetaMask/action-npm-publish@v6
         with:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           subteam: S042S7RE4AE # @metamask-npm-publishers
@@ -61,6 +60,9 @@ jobs:
     needs: publish-npm-dry-run
     runs-on: ubuntu-latest
     environment: npm-publish
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v1
@@ -72,10 +74,13 @@ jobs:
         with:
           name: publish-release-artifacts-${{ github.sha }}
       - name: Publish
-        uses: MetaMask/action-npm-publish@v5
+        uses: MetaMask/action-npm-publish@v6
         with:
-          # This `NPM_TOKEN` needs to be manually set per-repository.
-          # Look in the repository settings under "Environments", and set this token in the `npm-publish` environment.
+          # This `NPM_TOKEN` needs to be manually set to publish a package for
+          # the first time only.
+          # Look in the repository settings under "Environments", and set this
+          # token in the `npm-publish` environment, and delete it after the
+          # initial publish.
           npm-token: ${{ secrets.NPM_TOKEN }}
         env:
           SKIP_PREPACK: true


### PR DESCRIPTION
## Summary

- Updates `action-npm-publish` from v5 to v6
- Adds `id-token: write` permission to `publish-release` job in `main.yml`
- Adds `permissions` block to `publish-npm` job in `publish-release.yml`
- Makes `NPM_TOKEN` secret optional

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the production npm release path and auth model (OIDC + optional token); misconfiguration could block publishes or affect first-time package setup.
> 
> **Overview**
> Upgrades the release pipeline to **`MetaMask/action-npm-publish@v6`** for both the dry-run and production npm publish jobs, matching v6’s expected GitHub Actions setup.
> 
> **OIDC / permissions:** The reusable `publish-release` invocation in `main.yml` now grants **`id-token: write`**, and the **`publish-npm`** job sets explicit permissions (`contents: read`, `id-token: write`) so the action can authenticate without relying only on a long-lived token where OIDC is supported.
> 
> **Secrets contract:** `NPM_TOKEN` on the callable workflow is now **optional** (`required: false`), and comments clarify it is only needed for a **first-time** package publish; the dry-run step no longer documents omitting `npm-token` explicitly. The real publish step still passes `npm-token: ${{ secrets.NPM_TOKEN }}` when configured.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ae62d352b8c492e67e7fdfde8b23d71cf57306e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->