### PR TITLE
ci: Add missing top-level `permissions` to publish-release workflow

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -9,6 +9,10 @@ on:
         required: true
       PUBLISH_DOCS_TOKEN:
         required: true
+
+permissions:
+  contents: read
+
 jobs:
   publish-release:
     permissions:


### PR DESCRIPTION
## Summary

- Adds top-level `permissions: contents: read` to `publish-release.yml`, restricting default token permissions for all jobs in the workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only least-privilege change; jobs that need write or OIDC permissions still declare them explicitly.
> 
> **Overview**
> Adds workflow-level **`permissions: contents: read`** to `.github/workflows/publish-release.yml` so the default `GITHUB_TOKEN` scope is read-only for every job in this reusable release workflow.
> 
> Jobs that still need broader access keep their existing **job-level** overrides (for example `contents: write` on release/docs jobs and `id-token: write` on `publish-npm`), so release behavior should stay the same while tightening the baseline token permissions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b92d0c60bd58f1e47fd59644506cf0902b96a6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->